### PR TITLE
TLF-99 Updating Legal representative's details

### DIFF
--- a/apps/coa/behaviours/check-oisc-sra-number.js
+++ b/apps/coa/behaviours/check-oisc-sra-number.js
@@ -1,0 +1,30 @@
+const validators = require('hof/controller/validation/validators');
+
+module.exports = superclass => class extends superclass {
+  validate(req, res, next) {
+    const oiscOrSraNumber = req.form.values['oisc-sra-number'];
+    const maxLength = 8;
+    const minLength = 5;
+    if (validators.numeric(oiscOrSraNumber) &&
+        (oiscOrSraNumber.length < minLength || oiscOrSraNumber.length > maxLength )) {
+      return next({
+        'oisc-sra-number': new this.ValidationError(
+          'oisc-sra-number',
+          {
+            type: 'checkSRANum'
+          })
+      });
+    }
+    if(!validators.numeric(oiscOrSraNumber) && !validators.regex(oiscOrSraNumber.toUpperCase(), /^[A-Z]\d{9}$/)) {
+      return next({
+        'oisc-sra-number': new this.ValidationError(
+          'oisc-sra-number',
+          {
+            type: 'checkOISCNum'
+          })
+      });
+    }
+    super.validate(req, res, next);
+    return next;
+  }
+};

--- a/apps/coa/behaviours/check-oisc-sra-number.js
+++ b/apps/coa/behaviours/check-oisc-sra-number.js
@@ -5,22 +5,14 @@ module.exports = superclass => class extends superclass {
     const oiscOrSraNumber = req.form.values['oisc-sra-number'];
     const maxLength = 8;
     const minLength = 5;
-    if (validators.numeric(oiscOrSraNumber) &&
-        (oiscOrSraNumber.length < minLength || oiscOrSraNumber.length > maxLength )) {
+    if ((validators.numeric(oiscOrSraNumber) &&
+            (oiscOrSraNumber.length < minLength || oiscOrSraNumber.length > maxLength )) ||
+          (!validators.numeric(oiscOrSraNumber) && !validators.regex(oiscOrSraNumber.toUpperCase(), /^[A-Z]\d{9}$/))) {
       return next({
         'oisc-sra-number': new this.ValidationError(
           'oisc-sra-number',
           {
-            type: 'checkSRANum'
-          })
-      });
-    }
-    if(!validators.numeric(oiscOrSraNumber) && !validators.regex(oiscOrSraNumber.toUpperCase(), /^[A-Z]\d{9}$/)) {
-      return next({
-        'oisc-sra-number': new this.ValidationError(
-          'oisc-sra-number',
-          {
-            type: 'checkOISCNum'
+            type: 'OISCSRANum'
           })
       });
     }

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -332,7 +332,7 @@ module.exports = {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'oisc-sra-number': {
-    validate: ['notUrl'],
+    validate: ['notUrl', 'required'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'legal-address-line-1': {

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -249,9 +249,11 @@ module.exports = {
     className: ['govuk-input', 'govuk-input--width-10']
   },
   'legal-company-name': {
+    validate: ['notUrl'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'oisc-sra-number': {
+    validate: ['notUrl'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'legal-address-line-1': {

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -209,10 +209,12 @@ module.exports = {
     ]
   },
   'postal-address-line-1': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'postal-address-line-2': {
-    validate: ['notUrl', { type: 'maxlength', arguments: [250] }]
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'postal-address-town-or-city': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -248,6 +248,33 @@ module.exports = {
     formatter: ['ukPostcode'],
     className: ['govuk-input', 'govuk-input--width-10']
   },
+  'legal-company-name': {
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'oisc-sra-number': {
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'legal-address-line-1': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'legal-address-line-2': {
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'legal-address-town-or-city': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'legal-address-county': {
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'legal-address-postcode': {
+    validate: ['required', 'notUrl', 'postcode'],
+    formatter: ['ukPostcode'],
+    className: ['govuk-input', 'govuk-input--width-10']
+  },
   'privacy-check': {
     mixin: 'checkbox',
     validate: ['required']

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -330,7 +330,7 @@ module.exports = {
     className: ['govuk-input', 'govuk-input--width-10']
   },
   'legal-company-name': {
-    validate: ['notUrl'],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'oisc-sra-number': {

--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -116,7 +116,8 @@ module.exports = {
       next: '/home-address'
     },
     '/home-address': {
-      fields: ['home-address-line-1',
+      fields: [
+        'home-address-line-1',
         'home-address-line-2',
         'home-address-town-or-city',
         'home-address-county',
@@ -168,7 +169,15 @@ module.exports = {
       ]
     },
     '/legal-details': {
-      fields: [],
+      fields: [
+        'legal-company-name',
+        'oisc-sra-number',
+        'legal-address-line-1',
+        'legal-address-line-2',
+        'legal-address-town-or-city',
+        'legal-address-county',
+        'legal-address-postcode'
+      ],
       next: '/check-answers',
       forks: [
         {

--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -5,6 +5,7 @@ const Aggregate = require('./behaviours/aggregator');
 const setDateErrorLink = require('./behaviours/set-date-error-link');
 const ModifyChangeURL = require('./behaviours/modify-change-link');
 const saveDesiredContent = require('./behaviours/save-desired-content.js');
+const checkOiscSraNumber = require('./behaviours/check-oisc-sra-number.js');
 
 /**
  * Checks if a given field value matches a conditional value based on the request object.
@@ -175,6 +176,7 @@ module.exports = {
       ]
     },
     '/legal-details': {
+      behaviours: [checkOiscSraNumber],
       fields: [
         'legal-company-name',
         'oisc-sra-number',

--- a/apps/coa/sections/summary-data-sections.js
+++ b/apps/coa/sections/summary-data-sections.js
@@ -160,23 +160,23 @@ module.exports = {
       },
       {
         step: '/legal-details',
-        field: 'legal-address-line-1'
-      },
-      {
-        step: '/legal-details',
-        field: 'legal-address-line-2'
-      },
-      {
-        step: '/legal-details',
-        field: 'legal-address-town-or-city'
-      },
-      {
-        step: '/legal-details',
-        field: 'legal-address-county'
-      },
-      {
-        step: '/legal-details',
-        field: 'legal-address-postcode'
+        field: 'legal-representative-address-details',
+        parse: (list, req) => {
+          if (!req.sessionModel.get('steps').includes('/legal-details')) {
+            return null;
+          }
+          const legalAddressDetails = [];
+          legalAddressDetails.push(req.sessionModel.get('legal-address-line-1'));
+          if(req.sessionModel.get('legal-address-line-2')) {
+            legalAddressDetails.push(req.sessionModel.get('legal-address-line-2'));
+          }
+          legalAddressDetails.push(req.sessionModel.get('legal-address-town-or-city'));
+          if(req.sessionModel.get('legal-address-county')) {
+            legalAddressDetails.push(req.sessionModel.get('legal-address-county'));
+          }
+          legalAddressDetails.push(req.sessionModel.get('legal-address-postcode'));
+          return legalAddressDetails.join('\n');
+        }
       }
     ]
   }

--- a/apps/coa/sections/summary-data-sections.js
+++ b/apps/coa/sections/summary-data-sections.js
@@ -113,6 +113,34 @@ module.exports = {
           addressDetails.push(req.sessionModel.get('home-address-postcode'));
           return addressDetails.join('\n');
         }
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-company-name'
+      },
+      {
+        step: '/legal-details',
+        field: 'oisc-sra-number'
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-address-line-1'
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-address-line-2'
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-address-town-or-city'
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-address-county'
+      },
+      {
+        step: '/legal-details',
+        field: 'legal-address-postcode'
       }
     ]
   }

--- a/apps/coa/translations/src/en/fields.json
+++ b/apps/coa/translations/src/en/fields.json
@@ -119,6 +119,28 @@
   "home-address-postcode": {
     "label": "Postcode"
   },
+  "legal-company-name": {
+    "label": "Company name (optional)"
+  },
+  "oisc-sra-number": {
+    "label": "OISC or SRA number",
+    "hint": "Office of the Immigration Services Commissioner number or Solicitor’s Regulation Authority number"
+  },
+  "legal-address-line-1": {
+    "label": "Address line 1"
+  },
+  "legal-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "legal-address-town-or-city": {
+    "label": "Town or city"
+  },
+  "legal-address-county": {
+    "label": "County (optional)"
+  },
+  "legal-address-postcode": {
+    "label": "Postcode"
+  },
   "privacy-check": {
     "label": "I confirm that I have read and understood the Data Protection statement above."
   }

--- a/apps/coa/translations/src/en/pages.json
+++ b/apps/coa/translations/src/en/pages.json
@@ -108,14 +108,8 @@
       "home-address-details": {
         "label": "New home address"
       },
-      "legal-company-name": {
-        "label": "Company name"
-      },
-      "legal-address-line-2": {
-        "label": "Address line 2"
-      },
-      "legal-address-county": {
-        "label": "County"
+      "legal-representative-address-details": {
+        "label": "Legal representative postal address"
       }
     }
   }

--- a/apps/coa/translations/src/en/pages.json
+++ b/apps/coa/translations/src/en/pages.json
@@ -95,6 +95,15 @@
       },
       "home-address-details": {
         "label": "New home address"
+      },
+      "legal-company-name": {
+        "label": "Company name"
+      },
+      "legal-address-line-2": {
+        "label": "Address line 2"
+      },
+      "legal-address-county": {
+        "label": "County"
       }
     }
   }

--- a/apps/coa/translations/src/en/validation.json
+++ b/apps/coa/translations/src/en/validation.json
@@ -137,7 +137,8 @@
     },
 
     "legal-company-name": {
-        "notUrl": "Your answer must not contain URLs or links"
+        "notUrl": "Your answer must not contain URLs or links",
+        "maxlength": "Company name must be 200 characters or less"
     },
     "oisc-sra-number": {
         "required":"Enter an OISC or SRA number",

--- a/apps/coa/translations/src/en/validation.json
+++ b/apps/coa/translations/src/en/validation.json
@@ -142,8 +142,7 @@
     "oisc-sra-number": {
         "required":"Enter an OISC or SRA number",
         "notUrl": "Your answer must not contain URLs or links",
-        "checkSRANum":"SRA number should be in length between 5-8 digits. for example 12345 or 12345678",
-        "checkOISCNum":"OISC number should starts with a alphabet followed by 9 digits. for example A123456789"
+        "OISCSRANum":"Enter an OISC or SRA number in the correct format, for example F123456789 or 123456"
     },
     "legal-address-line-1": {
         "required": "Enter your house number or name",

--- a/apps/coa/translations/src/en/validation.json
+++ b/apps/coa/translations/src/en/validation.json
@@ -97,6 +97,36 @@
         "notUrl": "Your answer must not contain URLs or links",
         "postcode": "Enter a real UK postcode"
     },
+
+    "legal-company-name": {
+        "notUrl": "Your answer must not contain URLs or links"
+    },
+    "oisc-sra-number": {
+        "notUrl": "Your answer must not contain URLs or links"
+    },
+    "legal-address-line-1": {
+        "required": "Enter your house number or name",
+        "notUrl": "Your answer must not contain URLs or links",
+        "maxlength": "Address line 1 must be 250 characters or less"
+    },
+    "legal-address-line-2": {
+        "notUrl": "Your answer must not contain URLs or links",
+        "maxlength": "Address line 2 must be 250 characters or less"
+    },
+    "legal-address-town-or-city": {
+        "required": "Enter your town or city",
+        "notUrl": "Your answer must not contain URLs or links",
+        "maxlength": "Town/City must be 250 characters or less"
+    },
+    "legal-address-county": {
+        "notUrl": "Your answer must not contain URLs or links",
+        "maxlength": "County must be 250 characters or less"
+    },
+    "legal-address-postcode": {
+        "required": "Enter your UK postcode",
+        "notUrl": "Your answer must not contain URLs or links",
+        "postcode": "Enter a real UK postcode"
+    },
     "privacy-check": {
       "required": "Confirm you have read the Data Protection statement"
     }

--- a/apps/coa/translations/src/en/validation.json
+++ b/apps/coa/translations/src/en/validation.json
@@ -140,7 +140,10 @@
         "notUrl": "Your answer must not contain URLs or links"
     },
     "oisc-sra-number": {
-        "notUrl": "Your answer must not contain URLs or links"
+        "required":"Enter an OISC or SRA number",
+        "notUrl": "Your answer must not contain URLs or links",
+        "checkSRANum":"SRA number should be in length between 5-8 digits. for example 12345 or 12345678",
+        "checkOISCNum":"OISC number should starts with a alphabet followed by 9 digits. for example A123456789"
     },
     "legal-address-line-1": {
         "required": "Enter your house number or name",


### PR DESCRIPTION
## What? 
TLF-99 - Added Updating Legal representative's details page [TLF-99](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-99)
## Why? 
So that UKVI have current and accurate records of the legal representative
## How? 
Added the relevant fields, validation rules on the legal representative details page and displayed provided details on Check your answers page.
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


