### PR TITLE
TLF-152-fork-bug-which-details

### DIFF
--- a/apps/coa/behaviours/unset-address-steps.js
+++ b/apps/coa/behaviours/unset-address-steps.js
@@ -1,0 +1,25 @@
+module.exports = superclass => class extends superclass {
+  getValues(req, res, next) {
+    if (req.originalUrl.includes('/edit')) {
+      const matchedSteps = [];
+      const addressSteps = [
+        '/postal-address', '/old-address', '/legal-details', '/home-address', '/upload-postal-address',
+        '/upload-postal-address-summary', '/upload-address', '/upload-address-summary'
+      ];
+      const currentUserSession = req.sessionModel.get('steps');
+      // loop through the user session to check which address steps the user has completed
+      currentUserSession.forEach(function (step) {
+        addressSteps.forEach(function (addressStep) {
+          if (step === addressStep) {
+            matchedSteps.push(step);
+          }
+        });
+      });
+      // remove address steps from the current user session
+      const stepsToKeep = currentUserSession.filter(step => !matchedSteps.includes(step));
+      req.sessionModel.unset('steps');
+      req.sessionModel.set('steps', stepsToKeep);
+    }
+    return super.getValues(req, res, next);
+  }
+};

--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -5,6 +5,7 @@ const Aggregate = require('./behaviours/aggregator');
 const setDateErrorLink = require('./behaviours/set-date-error-link');
 const ModifyChangeURL = require('./behaviours/modify-change-link');
 const saveDesiredContent = require('./behaviours/save-desired-content.js');
+const unsetAddressSteps = require('./behaviours/unset-address-steps');
 
 /**
  * Checks if a given field value matches a conditional value based on the request object.
@@ -15,7 +16,7 @@ const saveDesiredContent = require('./behaviours/save-desired-content.js');
  * @returns {boolean} - Returns true if the field value matches the conditional value, false otherwise.
  */
 function forkCondition(req, fieldName, conditionalValue) {
-  const fieldValue = req.form.historicalValues?.[fieldName] || req.form.values[fieldName];
+  const fieldValue = req.sessionModel.get(`${fieldName}`);
   if (!fieldValue) return false;
   return Array.isArray(fieldValue) ? fieldValue.includes(conditionalValue) : fieldValue === conditionalValue;
 }
@@ -87,6 +88,7 @@ module.exports = {
     },
     '/which-details': {
       fields: ['which-details-updating'],
+      behaviours: [unsetAddressSteps],
       // The conditional check should be performed in reverse order, as the last fork takes over.
       forks: [
         {


### PR DESCRIPTION
## What? 
Relates [TLF-152](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-152)

Fix forking bug when the user selects change link on /check-answers for /which-details

## Why? 

The bug would redirect the user back to /check-answers after making a change on /which-details which prevented users from completing additional pages that should have followed in the form flow. 

## How? 

When the user selects 'change' on /check-answers the behaviour will unset the steps related to addresses this prevents the form from thinking its 'complete' and redirecting to /check-answers page.

_See hof>controller>controller.js:_

    const completed = s => {
      let step = s;
      if (req.baseUrl !== '/') {
        const re = new RegExp('^' + req.baseUrl);
        step = step.replace(re, '');
      }
      // Has the user already completed the step?
      return _.includes(req.sessionModel.get('steps'), step);
    };

and 

    if (req.params.action === 'edit') {
      if (!req.form.options.continueOnEdit && completed(next)) {
        next = confirmStep;
      }
      if (next !== confirmStep) {
        next += '/edit';
      }
    }

## Testing?

Locally

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


