### PR TITLE
TLF-61 - COA - Upload letter of authority (All 3 flows)

### DIFF
--- a/apps/coa/behaviours/save-desired-content.js
+++ b/apps/coa/behaviours/save-desired-content.js
@@ -11,7 +11,9 @@ module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     const whoIsApplying = req.form.values['who-are-you'];
     const isApplicant = whoIsApplying === 'applicant' ? true : false;
+    const isLegalRep = whoIsApplying === 'legal-representative' ? true : false;
     req.sessionModel.set('isApplicant', isApplicant);
+    req.sessionModel.set('isLegalRep', isLegalRep);
     return super.saveValues(req, res, next);
   }
 };

--- a/apps/coa/fields/index.js
+++ b/apps/coa/fields/index.js
@@ -361,11 +361,5 @@ module.exports = {
   'privacy-check': {
     mixin: 'checkbox',
     validate: ['required']
-  },
-
-  'document-file': {
-    mixin: 'input-file',
-    validate: ['required'],
-    labelClassName: 'visuallyhidden'
   }
 };

--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -58,24 +58,10 @@ module.exports = {
       behaviours: [saveDesiredContent],
       fields: ['who-are-you', 'legal-representative-name', 'someone-else-name'],
       next: '/contact-details',
-      forks: [
-        {
-          target: '/legal-representative',
-          condition: {
-            field: 'who-are-you',
-            value: 'legal-representative'
-          }
-        }
-      ],
-      continueOnEdit: true
-    },
-    '/legal-representative': {
-      fields: ['email', 'telephone', 'client-email', 'client-telephone'],
-      next: '/identity-number',
       continueOnEdit: true
     },
     '/contact-details': {
-      fields: ['email', 'telephone'],
+      fields: ['email', 'telephone', 'client-email', 'client-telephone'],
       next: '/identity-number',
       continueOnEdit: true
     },
@@ -146,6 +132,10 @@ module.exports = {
           condition: req => forkCondition(req, 'who-are-you', 'applicant')
         },
         {
+          target: '/upload-letter',
+          condition: req => forkCondition(req, 'who-are-you', 'legal-representative')
+        },
+        {
           target: '/legal-details',
           condition: req => forkCondition(req, 'which-details-updating', 'legal-details')
         },
@@ -181,6 +171,10 @@ module.exports = {
           condition: req => forkCondition(req, 'who-are-you', 'applicant')
         },
         {
+          target: '/upload-letter',
+          condition: req => forkCondition(req, 'who-are-you', 'legal-representative')
+        },
+        {
           target: '/legal-details',
           condition: req => forkCondition(req, 'which-details-updating', 'legal-details')
         }
@@ -197,13 +191,20 @@ module.exports = {
         'legal-address-county',
         'legal-address-postcode'
       ],
+      next: '/upload-letter',
+      continueOnEdit: true
+    },
+    '/upload-letter': {
+      behaviours: [SaveDocument('letter-of-authority', 'file-upload'), RemoveDocument('letter-of-authority')],
+      fields: ['file-upload'],
       next: '/check-answers',
       forks: [
         {
           target: '/update-dependant',
           condition: req => forkCondition(req, 'who-are-you', 'applicant')
         }
-      ]
+      ],
+      continueOnEdit: true
     },
     '/update-dependant': {
       fields: ['change-dependant-details'],

--- a/apps/coa/sections/summary-data-sections.js
+++ b/apps/coa/sections/summary-data-sections.js
@@ -80,6 +80,15 @@ module.exports = {
         parse: documents => {
           return Array.isArray(documents) && documents.length > 0  ? documents.map(doc => doc.name).join('\n') : null;
         }
+      },
+      {
+        step: '/upload-letter',
+        field: 'letter-of-authority',
+        parse: (documents, req) => {
+          return req.sessionModel.get('isLegalRep') &&
+           Array.isArray(documents) && documents.length > 0 ?
+            documents.map(doc => doc.name).join('\n') : null;
+        }
       }
     ]
   },
@@ -190,6 +199,18 @@ module.exports = {
           }
           legalAddressDetails.push(req.sessionModel.get('legal-address-postcode'));
           return legalAddressDetails.join('\n');
+        }
+      },
+      {
+        step: '/upload-letter',
+        field: 'letter-of-authority',
+        parse: (documents, req) => {
+          if (!req.sessionModel.get('steps').includes('/upload-letter')) {
+            return null;
+          }
+          return !req.sessionModel.get('isLegalRep') &&
+            Array.isArray(documents) && documents.length > 0 ?
+            documents.map(doc => doc.name).join('\n') : null;
         }
       }
     ]

--- a/apps/coa/translations/src/en/pages.json
+++ b/apps/coa/translations/src/en/pages.json
@@ -46,6 +46,12 @@
   "legal-details": {
     "header": "Enter your legal representative’s details"
   },
+  "upload-letter": {
+    "header": "Upload letter of authority ",
+    "upload-letter-intro": "To prove {{#values.isApplicant}}your{{/values.isApplicant}}{{^values.isApplicant}}{{values.nameWithPossession}}{{/values.isApplicant}} legal representation,",
+    "upload-letter-instructions": "you must upload a scanned copy of a solicitor's letter of authority. This should be on paper with a letterhead.",
+    "upload-letter-requirements": "The scan must be clear and easy to read. You must scan and upload the whole document, if it is more than one page."
+  },
   "dependant-summary": {
     "header": "Dependants"
   },
@@ -143,6 +149,9 @@
       },
       "home-address-documents": {
         "label": "Proof of home address"
+      },
+      "letter-of-authority": {
+        "label": "Letter of authority"
       }
     }
   }

--- a/apps/coa/views/contact-details.html
+++ b/apps/coa/views/contact-details.html
@@ -1,0 +1,15 @@
+{{<partials-page}}
+  {{$page-content}}
+    
+  {{#input-text}}email{{/input-text}}
+  {{#input-text}}telephone{{/input-text}}
+ 
+  {{#values.isLegalRep}}
+    {{#input-text}}client-email{{/input-text}}
+    {{#input-text}}client-telephone{{/input-text}}
+  {{/values.isLegalRep}}
+  
+  {{#input-submit}}continue{{/input-submit}}
+  
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/coa/views/upload-address.html
+++ b/apps/coa/views/upload-address.html
@@ -15,7 +15,7 @@
   {{/values.home-address-documents}}
 
   {{#values.home-address-documents.length}}
-  <h2 class="govuk-heading-m">You have uploaded {{values.home-address-documents.length}} file</h2>
+  <h2 class="govuk-heading-m">You have uploaded {{values.home-address-documents.length}} file(s)</h2>
   <table class="loop-summary-table">
     <tbody class="govuk-table__body">
       {{#values.home-address-documents}}

--- a/apps/coa/views/upload-identity.html
+++ b/apps/coa/views/upload-identity.html
@@ -15,7 +15,7 @@
   {{/values.identity-documents}}
 
   {{#values.identity-documents.length}}
-  <h2 class="govuk-heading-m">You have uploaded {{values.identity-documents.length}} file</h2>
+  <h2 class="govuk-heading-m">You have uploaded {{values.identity-documents.length}} file(s)</h2>
   <table class="loop-summary-table">
     <tbody class="govuk-table__body">
       {{#values.identity-documents}}

--- a/apps/coa/views/upload-letter.html
+++ b/apps/coa/views/upload-letter.html
@@ -15,7 +15,7 @@
   {{/values.letter-of-authority}}
 
   {{#values.letter-of-authority.length}}
-  <h2 class="govuk-heading-m">You have uploaded {{values.letter-of-authority.length}} file(s)</h2>
+  <h2 class="govuk-heading-m">You have uploaded {{values.letter-of-authority.length}} file</h2>
   <table class="loop-summary-table">
     <tbody class="govuk-table__body">
       {{#values.letter-of-authority}}

--- a/apps/coa/views/upload-letter.html
+++ b/apps/coa/views/upload-letter.html
@@ -1,0 +1,38 @@
+{{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}} {{$page-content}}
+<p>{{#t}}pages.upload-letter.upload-letter-intro{{/t}} {{#t}}pages.upload-letter.upload-letter-instructions{{/t}}</p>
+<p>{{#t}}pages.upload-letter.upload-letter-requirements{{/t}}</p>
+
+
+  <div class="govuk-form-group">
+    <label class="govuk-label bold" for="file-upload">
+      Upload a file
+    </label>
+    <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="letter-of-authority">
+  </div>
+
+  {{^values.letter-of-authority}}
+  <h2 class="govuk-heading-m">No documents uploaded</h2>
+  {{/values.letter-of-authority}}
+
+  {{#values.letter-of-authority.length}}
+  <h2 class="govuk-heading-m">You have uploaded {{values.letter-of-authority.length}} file(s)</h2>
+  <table class="loop-summary-table">
+    <tbody class="govuk-table__body">
+      {{#values.letter-of-authority}}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{name}}</td>
+        <td><a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.delete{{/t}}</a></td>
+      </tr>
+      {{/values.letter-of-authority}}
+    </tbody>
+  </table>
+  {{/values.letter-of-authority.length}}
+
+  {{#markdown}}what-file-types{{/markdown}}
+  
+    <button class="govuk-button govuk-button" name="continueWithoutUpload" value="letter-of-authority">
+      {{#t}}buttons.continue{{/t}}
+    </button>
+    
+  {{/page-content}}
+  {{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -49,7 +49,7 @@ module.exports = {
         limit: 3,
         limitValidationError: 'maxAddressDocsUploads'
       },
-      'cert-of-authority-documents': {
+      'letter-of-authority': {
         limit: 1,
         limitValidationError: 'maxCertOfAuthorityUploads'
       }


### PR DESCRIPTION
### What
TLF-61 - COA - Upload letter of authority [TLF-61](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-61)

### Why
- Newly implemented Upload letter of authority with new uploading screen design for all 3 flows. 
- Added new validation rules for upload
  - To check maximum file upload Limit for each sections
  - To check the file uploading with same file name.
- Made changes to retain email and telephone field value in session
  - setting new variable in sessionModel for Leg-rep route (isLegalRep) and displayed the two different fields if the value is true. 


### How
- Upload starts when the file is selected - New screen design
  - apps/coa/views/upload-letter.html
- User can upload one file at a time
- File count limit - User can only upload limited amount of files - 3 max for proof of home address
- User aren't able to upload the same file again
  - apps/coa/behaviours/save-document.js

### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local

