### PR TITLE
TLF-65: Additional logs on file upload

### DIFF
--- a/.devcontainer/devcontainer.env.sample
+++ b/.devcontainer/devcontainer.env.sample
@@ -1,3 +1,5 @@
+NODE_ENV=development
+
 REDIS_HOST=hof-redis
 
 # FileVault

--- a/apps/coa/behaviours/save-document.js
+++ b/apps/coa/behaviours/save-document.js
@@ -47,7 +47,7 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
     return super.validateField(key, req);
   }
 
-  saveValues(req, res, next) {
+  async saveValues(req, res, next) {
     const documentsByCategory = req.sessionModel.get(documentCategory) || [];
 
     if (req.files[name]) {
@@ -59,12 +59,13 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
       };
       const model = new Model(document);
 
-      return model.save()
-        .then(() => {
-          req.sessionModel.set(documentCategory, [...documentsByCategory, model.toJSON()]);
-          return res.redirect(`${req.baseUrl}${req.path}`);
-        })
-        .catch(next);
+      try {
+        await model.save();
+        req.sessionModel.set(documentCategory, [...documentsByCategory, model.toJSON()]);
+        return res.redirect(`${req.baseUrl}${req.path}`);
+      } catch (error) {
+        return next(new Error(`Failed to save document: ${error}`));
+      }
     }
     return super.saveValues.apply(this, arguments);
   }

--- a/apps/coa/behaviours/save-document.js
+++ b/apps/coa/behaviours/save-document.js
@@ -3,17 +3,17 @@
 const config = require('../../../config');
 const Model = require('../models/file-upload');
 
-module.exports = (documentCategory, name) => superclass => class extends superclass {
+module.exports = (documentCategory, fieldName) => superclass => class extends superclass {
   process(req) {
-    if (req.files && req.files[name]) {
-      req.form.values[name] = req.files[name].name;
-      req.log('info', `Processing document: ${req.form.values[name]}`);
+    if (req.files && req.files[fieldName]) {
+      req.form.values[fieldName] = req.files[fieldName].name;
+      req.log('info', `Processing field ${fieldName} with value: ${req.files[fieldName].name}`);
     }
     super.process.apply(this, arguments);
   }
 
   validateField(key, req) {
-    const fileToBeValidated = req.files[name];
+    const fileToBeValidated = req.files[fieldName];
     const documentsByCategory = req.sessionModel.get(documentCategory) || [];
     const validationErrorFunc = (type, args) => new this.ValidationError(key, { type: type, arguments: [args] });
 
@@ -24,7 +24,7 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
       const uploadSize = fileToBeValidated.size;
       const mimetype = fileToBeValidated.mimetype;
       const uploadSizeTooBig = uploadSize > config.upload.maxFileSizeInBytes;
-      const uploadSizeBeyondServerLimits = uploadSize === null;
+      const uploadSizeBeyondServerLimits = fileToBeValidated.truncated;
 
       const invalidSize = uploadSizeTooBig || uploadSizeBeyondServerLimits;
       const invalidMimetype = !config.upload.allowedMimeTypes.includes(mimetype);
@@ -32,7 +32,7 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
       const numberOfDocsUploaded = documentsByCategory.length;
       const documentCategoryConfig = config.upload.documentCategories[documentCategory];
 
-      const isDuplicateFile = documentsByCategory.some(file => file.name === req.files[name].name);
+      const isDuplicateFile = documentsByCategory.some(file => file.name === req.files[fieldName].name);
 
       if (invalidSize) {
         return validationErrorFunc('maxFileSize');
@@ -41,7 +41,7 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
       } else if (numberOfDocsUploaded >= documentCategoryConfig.limit) {
         return validationErrorFunc(documentCategoryConfig.limitValidationError, [documentCategoryConfig.limit]);
       } else if (isDuplicateFile) {
-        return validationErrorFunc('isDuplicateFileName', [req.files[name].name]);
+        return validationErrorFunc('isDuplicateFileName', [req.files[fieldName].name]);
       }
     }
     return super.validateField(key, req);
@@ -50,12 +50,12 @@ module.exports = (documentCategory, name) => superclass => class extends supercl
   async saveValues(req, res, next) {
     const documentsByCategory = req.sessionModel.get(documentCategory) || [];
 
-    if (req.files[name]) {
-      req.log('info', `Saving document: ${req.files[name].name} in ${documentCategory} category`);
+    if (req.files[fieldName]) {
+      req.log('info', `Saving document: ${req.files[fieldName].name} in ${documentCategory} category`);
       const document = {
-        name: req.files[name].name,
-        data: req.files[name].data,
-        mimetype: req.files[name].mimetype
+        name: req.files[fieldName].name,
+        data: req.files[fieldName].data,
+        mimetype: req.files[fieldName].mimetype
       };
       const model = new Model(document);
 

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -36,7 +36,7 @@ module.exports = class UploadModel extends Model {
       };
       reqConf.method = 'POST';
 
-      return this._request(reqConf, (err, response) => {
+      return this.request(reqConf, (err, response) => {
         if (err) {
           logger.error(`File upload failed: ${err.message},
             error: ${JSON.stringify(err)},

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -108,7 +108,6 @@ module.exports = class UploadModel extends Model {
         }
 
         logger.info('Successfully retrieved access token');
-        logger.info('Access token: ' + parsedBody.access_token);
         return resolve({
           bearer: parsedBody.access_token
         });

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -39,14 +39,14 @@ module.exports = class UploadModel extends Model {
       return this._request(reqConf, (err, response) => {
         if (err) {
           logger.error(`File upload failed: ${err.message},
-            error: ${JSON.stringify(error)},
+            error: ${JSON.stringify(err)},
             reqConf: ${JSON.stringify(reqConf)}`);
           return reject(new Error(`File upload failed: ${err.message}`));
         }
 
         logger.info('Response from file-vault:');
         logger.info(response);
-        resolve(response);
+        return resolve(response);
       });
     })
       .then(result => {

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -35,18 +35,18 @@ module.exports = class UploadModel extends Model {
         }
       };
       reqConf.method = 'POST';
+
       return this._request(reqConf, (err, response) => {
+        if (err) {
+          logger.error(`File upload failed: ${err.message},
+            error: ${JSON.stringify(error)},
+            reqConf: ${JSON.stringify(reqConf)}`);
+          return reject(new Error(`File upload failed: ${err.message}`));
+        }
+
         logger.info('Response from file-vault:');
         logger.info(response);
-
-        if (err) {
-          logger.error(`File upload failed: ${err.message}`);
-          reject(new Error(`File upload failed: ${err.message}`));
-        } else {
-          logger.info('File uploaded successfully:');
-          logger.info(response);
-          resolve(response);
-        }
+        resolve(response);
       });
     })
       .then(result => {
@@ -88,13 +88,8 @@ module.exports = class UploadModel extends Model {
 
     return new Promise((resolve, reject) => {
       return this._request(tokenReq, (err, response) => {
-        if (err || response.statusCode !== 200) {
-          let errorMsg = 'Error occurred';
-          if (err) {
-            errorMsg += ': ' + err;
-          } else {
-            errorMsg += '. Status code: ' + response.statusCode;
-          }
+        if (err) {
+          const errorMsg = `Error occurred: ${JSON.stringify(err)}`;
           logger.error(errorMsg);
           return reject(new Error(errorMsg));
         }

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -55,7 +55,7 @@ module.exports = class UploadModel extends Model {
       .then(result => {
         try {
           return this.set({
-            url: result.url
+            url: result.url.replace('/file/', '/file/generate-link/').split('?')[0]
           });
         } catch (err) {
           logger.error(`No url in response: ${err.message}`);

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -40,25 +40,25 @@ module.exports = class UploadModel extends Model {
           logger.error(`File upload failed: ${err.message}`);
           reject(new Error(`File upload failed: ${err.message}`));
         } else {
-          logger.info(`File uploaded successfully:`);
+          logger.info('File uploaded successfully:');
           logger.info(data);
           resolve(data);
         }
       });
     })
-    .then(result => { 
-      try {
-        return this.set({
-          url: result.url
-        });
-      } catch (err) {
-        logger.error(`No url in response: ${err.message}`);
-        throw new Error(`No url in response: ${err.message}`);
-      }
-    })
-    .then(() => {
-      return this.unset('data');
-    });
+      .then(result => {
+        try {
+          return this.set({
+            url: result.url
+          });
+        } catch (err) {
+          logger.error(`No url in response: ${err.message}`);
+          throw new Error(`No url in response: ${err.message}`);
+        }
+      })
+      .then(() => {
+        return this.unset('data');
+      });
   }
 
   auth() {

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -44,8 +44,11 @@ module.exports = class UploadModel extends Model {
           return reject(new Error(`File upload failed: ${err.message}`));
         }
 
-        logger.info('Response from file-vault:');
-        logger.info(response);
+        if (Object.keys(response).length === 0) {
+          return reject(new Error('Received empty response from file-vault'));
+        }
+
+        logger.info(`Received response from file-vault with keys: ${Object.keys(response)}`);
         return resolve(response);
       });
     })

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -36,7 +36,6 @@ module.exports = class UploadModel extends Model {
       };
       reqConf.method = 'POST';
       return this._request(reqConf, (err, response) => {
-
         logger.info('Response from file-vault:');
         logger.info(response);
 

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -35,14 +35,18 @@ module.exports = class UploadModel extends Model {
         }
       };
       reqConf.method = 'POST';
-      return this.request(reqConf, (err, data) => {
+      return this._request(reqConf, (err, response) => {
+
+        logger.info('Response from file-vault:');
+        logger.info(response);
+
         if (err) {
           logger.error(`File upload failed: ${err.message}`);
           reject(new Error(`File upload failed: ${err.message}`));
         } else {
           logger.info('File uploaded successfully:');
-          logger.info(data);
-          resolve(data);
+          logger.info(response);
+          resolve(response);
         }
       });
     })

--- a/apps/coa/sections/change-details-data-sections.js
+++ b/apps/coa/sections/change-details-data-sections.js
@@ -83,13 +83,13 @@ module.exports = {
         omitChangeLink: true
       },
       {
-        step: '/legal-representative',
+        step: '/contact-details',
         field: 'legal-representative-email',
         parse: (list, req) => {
-          if (!req.sessionModel.get('steps').includes('/legal-representative')) {
+          if (!req.sessionModel.get('steps').includes('/contact-details')) {
             return null;
           }
-          return req.sessionModel.get('email');
+          return req.sessionModel.get('isLegalRep') ? req.sessionModel.get('email') : null ;
         },
         omitChangeLink: true
       }

--- a/apps/coa/sections/change-details-data-sections.js
+++ b/apps/coa/sections/change-details-data-sections.js
@@ -89,7 +89,7 @@ module.exports = {
           if (!req.sessionModel.get('steps').includes('/contact-details')) {
             return null;
           }
-          return req.sessionModel.get('isLegalRep') ? req.sessionModel.get('email') : null ;
+          return req.sessionModel.get('isLegalRep') ? req.sessionModel.get('email') : null;
         },
         omitChangeLink: true
       }

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -126,7 +126,7 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk/file
+              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk/file
             {{ end }}
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -125,8 +125,6 @@ spec:
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG
               value: "*"
-            - name: NODE_ENV
-              value: "development"
             {{ end }}
           {{ if not (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
           livenessProbe:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -82,17 +82,11 @@ spec:
                   #encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: "31536000" # 365 days in seconds
-            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: "604800" # 7 days in seconds
-            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: "604800" # 7 days in seconds
-            {{ end }}
+              value: "120" # 2 minutes in seconds
             - name: RETURN_ORIGINAL_SIGNED_URL
               value: "no"
             - name: ALLOW_GENERATE_LINK_ROUTE
-              value: "no"
+              value: "yes"
             - name: KEYCLOAK_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -131,6 +131,8 @@ spec:
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG
               value: "*"
+            - name: NODE_ENV
+              value: "development"
             {{ end }}
           {{ if not (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
           livenessProbe:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -82,7 +82,7 @@ spec:
                   #encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMES }}
+            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: "31536000" # 365 days in seconds
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: "604800" # 7 days in seconds

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -82,7 +82,7 @@ spec:
                   #encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMES
+            {{ if eq .KUBE_NAMES }}
               value: "31536000" # 365 days in seconds
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: "604800" # 7 days in seconds

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -81,6 +81,18 @@ spec:
                   name: file-vault
                   #encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
+            - name: AWS_EXPIRY_TIME
+            {{ if eq .KUBE_NAMES
+              value: "31536000" # 365 days in seconds
+            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+              value: "604800" # 7 days in seconds
+            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+              value: "604800" # 7 days in seconds
+            {{ end }}
+            - name: RETURN_ORIGINAL_SIGNED_URL
+              value: "no"
+            - name: ALLOW_GENERATE_LINK_ROUTE
+              value: "no"
             - name: KEYCLOAK_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -115,7 +115,7 @@ spec:
                   # encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMES
+            {{ if eq .KUBE_NAMES }}
               value: "31536000" # 365 days in seconds
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: "604800" # 7 days in seconds

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -115,7 +115,7 @@ spec:
                   # encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMES }}
+            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: "31536000" # 365 days in seconds
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: "604800" # 7 days in seconds

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -126,6 +126,12 @@ spec:
               value: "no"
             - name: ALLOW_GENERATE_LINK_ROUTE
               value: "no"
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            - name: DEBUG
+              value: "*"
+            - name: NODE_ENV
+              value: "development"
+            {{ end }}
           securityContext:
             runAsNonRoot: true
 
@@ -155,16 +161,6 @@ spec:
                 secretKeyRef:
                   name: keycloak-client
                   key: id
-            - name: KEYCLOAK_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-user
-                  key: username
-            - name: KEYCLOAK_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-user
-                  key: password
             - name: PROXY_LISTEN
               value: 127.0.0.1:3001
             - name: PROXY_UPSTREAM_URL

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -64,7 +64,7 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             - name: DEBUG
               value: "*"
             {{ end }}
@@ -173,7 +173,7 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             {{ end }}
           command:
             - "/opt/keycloak-proxy"

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -115,17 +115,11 @@ spec:
                   # encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
             - name: AWS_EXPIRY_TIME
-            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: "31536000" # 365 days in seconds
-            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: "604800" # 7 days in seconds
-            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: "604800" # 7 days in seconds
-            {{ end }}
+              value: "120" # 2 minutes in seconds
             - name: RETURN_ORIGINAL_SIGNED_URL
               value: "no"
             - name: ALLOW_GENERATE_LINK_ROUTE
-              value: "no"
+              value: "yes"
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG
               value: "*"

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -114,8 +114,18 @@ spec:
                   name: file-vault
                   # encryption_key is randomly generated password used to encrypt the params that are returned by file-vault
                   key: encryption_key
+            - name: AWS_EXPIRY_TIME
+            {{ if eq .KUBE_NAMES
+              value: "31536000" # 365 days in seconds
+            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+              value: "604800" # 7 days in seconds
+            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+              value: "604800" # 7 days in seconds
+            {{ end }}
+            - name: RETURN_ORIGINAL_SIGNED_URL
+              value: "no"
             - name: ALLOW_GENERATE_LINK_ROUTE
-              value: "yes"
+              value: "no"
           securityContext:
             runAsNonRoot: true
 
@@ -135,16 +145,26 @@ spec:
                 name: configmap
                 {{ end }}
           env:
-            - name: PROXY_CLIENT_SECRET
+            - name: KEYCLOAK_SECRET
               valueFrom:
                 secretKeyRef:
                   name: keycloak-client
                   key: secret
-            - name: PROXY_CLIENT_ID
+            - name: KEYCLOAK_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: keycloak-client
                   key: id
+            - name: KEYCLOAK_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-user
+                  key: username
+            - name: KEYCLOAK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-user
+                  key: password
             - name: PROXY_LISTEN
               value: 127.0.0.1:3001
             - name: PROXY_UPSTREAM_URL

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -123,8 +123,6 @@ spec:
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG
               value: "*"
-            - name: NODE_ENV
-              value: "development"
             {{ end }}
           securityContext:
             runAsNonRoot: true

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -145,12 +145,12 @@ spec:
                 name: configmap
                 {{ end }}
           env:
-            - name: KEYCLOAK_SECRET
+            - name: PROXY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: keycloak-client
                   key: secret
-            - name: KEYCLOAK_CLIENT_ID
+            - name: PROXY_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: keycloak-client

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -12,8 +12,8 @@ spec:
   tls:
   - hosts:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - fv-{{ .DRONE_BUILD_NUMBER }}.branch.sas-notprod.homeoffice.gov.uk
-    - fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+    - fv-{{ .DRONE_BUILD_NUMBER }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+    - fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
@@ -28,7 +28,7 @@ spec:
     {{ end }}
   rules:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
   - host: fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}

--- a/server.js
+++ b/server.js
@@ -36,13 +36,14 @@ app.use((req, res, next) => {
       });
 
       bb.on('file', (key, file, fileInfo) => {
+        logger.log('info', `Processing file: , ${JSON.stringify(file)}, ${JSON.stringify(fileInfo)}`);
         file.pipe(bl((err, d) => {
           if (err) {
             logger.log('error', `Error processing file : ${err}`);
             return;
           }
           if (!(d.length || fileInfo.filename)) {
-            logger.log('warn', 'Empty file received');
+            logger.log('warn', `Empty file received, ${d}, ${d.length}, ${fileInfo}, ${fileInfo.filename}`);
             return;
           }
 

--- a/server.js
+++ b/server.js
@@ -42,7 +42,10 @@ app.use((req, res, next) => {
   });
 
   bb.on('file', (key, file, fileInfo) => {
-    logger.info(`Processing file: filename: ${fileInfo.filename}, encoding: ${fileInfo.encoding}, mimeType: ${fileInfo.mimeType}`
+    logger.info(`Processing file: 
+      filename: ${fileInfo.filename},
+      encoding: ${fileInfo.encoding},
+      mimeType: ${fileInfo.mimeType}`
     );
 
     // eslint-disable-next-line consistent-return


### PR DESCRIPTION
## What? 
- Additional error handlers added around file upload functionality
- Changes to environment variables, for file-vault host
- Error handlers during parsing the multipart/form-data form, and during streaming operation;
- Returned link from file-vault is modified to be able generate link to signedURL on demand;
## Why? 
- Errors weren't processed, which prevented the detection of problems with file upload. 
- Host name didn't match the cert record, which prevented access to the file-vault service via browser.
- Then upload files should be available for the business within 365 days from the date of upload, to achieve this signedURL must be generate on demand
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


