### PR TITLE
Certificate error in file vault

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -16,7 +16,7 @@ if [[ $1 == 'tear_down' ]]; then
 
   $kd --delete -f kube/configmaps/configmap.yml
   $kd --delete -f kube/file-vault -f kube/app -f kube/redis 
-  echo "Torn Down UAT Branch - coa-$DRONE_SOURCE_BRANCH.internal.sas-coa-branch.homeoffice.gov.uk"
+  echo "Torn Down UAT Branch - coa-$DRONE_SOURCE_BRANCH.internal.branch.sas-notprod.homeoffice.gov.uk"
   exit 0
 fi
 
@@ -46,6 +46,6 @@ fi
 sleep $READY_FOR_TEST_DELAY
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
-  echo "App Branch - coa-$DRONE_SOURCE_BRANCH.internal.sas-coa-branch.homeoffice.gov.uk"
-  echo "Data Service Branch - data-service-$DRONE_SOURCE_BRANCH.sas-coa-branch.homeoffice.gov.uk"
+  echo "App Branch - coa-$DRONE_SOURCE_BRANCH.internal.branch.sas-notprod.homeoffice.gov.uk"
+  echo "Data Service Branch - data-service-$DRONE_SOURCE_BRANCH.branch.sas-notprod.homeoffice.gov.uk"
 fi

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -114,7 +114,7 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-uat.notprod.{{ .APP_NAME }}.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk/file
+              value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk/file
             {{ end }}
           {{ if not (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
           livenessProbe:

--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -15,8 +15,8 @@ spec:
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        - {{ .DRONE_BUILD_NUMBER }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
-        - {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+        - {{ .DRONE_BUILD_NUMBER }}.branch.sas-notprod.homeoffice.gov.uk
+        - {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
         - {{.APP_NAME}}.uat.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
@@ -31,7 +31,7 @@ spec:
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - host: {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+    - host: {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: {{.APP_NAME}}.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}

--- a/kube/app/ingress-internal.yml
+++ b/kube/app/ingress-internal.yml
@@ -13,8 +13,8 @@ spec:
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        - {{ .DRONE_BUILD_NUMBER }}.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk
-        - {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+        - {{ .DRONE_BUILD_NUMBER }}.internal.branch.sas-notprod.homeoffice.gov.uk
+        - {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.branch.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
         - {{ .APP_NAME }}.internal.uat.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
@@ -27,7 +27,7 @@ spec:
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - host: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+    - host: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.branch.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: {{ .APP_NAME }}.internal.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}

--- a/kube/certs/certificate-external.yml
+++ b/kube/certs/certificate-external.yml
@@ -5,9 +5,9 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
+  commonName: "*.branch.sas-notprod.homeoffice.gov.uk"
   dnsNames:
-  - "*.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
+  - "*.branch.sas-notprod.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod

--- a/kube/certs/certificate-internal.yml
+++ b/kube/certs/certificate-internal.yml
@@ -5,9 +5,9 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
+  commonName: "*.internal.branch.sas-notprod.homeoffice.gov.uk"
   dnsNames:
-  - "*.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
+  - "*.internal.branch.sas-notprod.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod


### PR DESCRIPTION
## What? 
Replace the environment variable branch environment: sas-coa-branch to branch.sas-notprod in the kube and bin files
## Why? 
The certificate when accessing the file vault url is failing. I am using the same url name structure for all resources such as file vault nginx and the app because they all use the same certificates. The rest of the projects in HOF has consistent hosts name and certificates.
## How? 
Replacing the environment variable branch environment: sas-coa-branch to branch.sas-notprod
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


