### PR TITLE
TLF-65: File upload - Changed unit for upload file size limit from MiB to MB  

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,7 +29,7 @@ module.exports = {
     steps: ['/overview', '/what-you-need', '/proof-of-identity', '/proof-of-address', '/update-details']
   },
   upload: {
-    maxFileSizeInBytes: 25 * 1024 * 1024, // 25MiB in bytes
+    maxFileSizeInBytes: 25 * 1000 * 1000, // 25MB in bytes
     hostname: process.env.FILE_VAULT_URL,
     allowedMimeTypes: [
       'application/pdf',


### PR DESCRIPTION
## What? 
Changed unit for upload file size limit from MiB to MB 

## Why? 
[MB](https://simple.wikipedia.org/wiki/Megabyte) vs [MiB](https://simple.wikipedia.org/wiki/Mebibyte)
There is a difference between 25MB and 25MiB
25MB = 25 * 1000 * 1000 = 25,000,000 bytes
25MiB = 25 * 1024 * 1024 = 26,214,400 bytes

Currently in the configuration we have 25MiB, so it would makes sense to change it to 25MB to avoid confusion for the end user, as MB is what the user would see in the Finder (Mac), however, MiB is the default unit for the File Explorer (Windows).

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


