### PR TITLE
UAT configmaps error

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -140,7 +140,7 @@ spec:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 name: {{ .APP_NAME }}-configmap-{{ .DRONE_SOURCE_BRANCH }}
                 {{ else }}
-                name: configmap
+                name: {{ .APP_NAME }}-configmap
                 {{ end }}
           env:
             - name: PROXY_CLIENT_SECRET


### PR DESCRIPTION
## What? 
In the file-vault-deployment .ymal  rename the configmaps to {{ .APP_NAME }}-configmap because the kubernetes configmaps name and the code are different
## Why? 
When deploying in UAT we get a configmaps error.
## How? 
In the file-vault-deployment .ymal  rename the configmaps to {{ .APP_NAME }}-configmap
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


