### PR TITLE
Add pipeline steps missing, remove staging and allow_skip

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -269,6 +269,34 @@ steps:
       branch: master
       event: push
 
+# Checks a build being promoted has passed, is on master which effectively means a healthy build on UAT
+  - name: sanity_check_build_prod
+    pull: if-not-exists
+    image: drone/cli:alpine@sha256:14409f7f7247befb9dd2effdb2f61ac40d1f5fbfb1a80566cf6f2f8d21f3be11
+    environment:
+      DRONE_SERVER:
+        from_secret: drone_server
+      DRONE_TOKEN:
+        from_secret: drone_token
+    commands:
+      - bin/sanity_check_build.sh
+    when:
+      target: PROD
+      event: promote
+
+  - name: clone_repos_prod
+    image: alpine/git
+    environment:
+      DRONE_GIT_USERNAME:
+        from_secret: drone_git_username
+      DRONE_GIT_TOKEN:
+        from_secret: drone_git_token
+    commands:
+      - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
+    when:
+      target: PROD
+      event: promote
+
     # Deploy to Production environment
   - name: deploy_to_prod
     pull: if-not-exists

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -31,11 +31,6 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/redis -f kube/app -f kube/file-vault
-elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
-  $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
-  $kd -f kube/redis -f kube/app -f kube/file-vault
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault

--- a/bin/sanity_check_build.sh
+++ b/bin/sanity_check_build.sh
@@ -6,8 +6,23 @@ export BRANCH=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Targe
 export EVENT=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
 export REFS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
 
-if [[ "$STATUS" != "success" || "$BRANCH" != "master" || "$EVENT" != "push" || "$REFS" != "refs/heads/master" ]]; then
-  echo "Build number $DRONE_BUILD_PARENT has not passed all relevant checks to Staging!"
+if [[ "$STATUS" != "success" ]]; then
+  echo "Build number $DRONE_BUILD_PARENT failed due to unsuccessful status."
+  exit 1
+fi
+
+if [[ "$BRANCH" != "master" ]]; then
+  echo "Build number $DRONE_BUILD_PARENT failed because it's not on the master branch."
+  exit 1
+fi
+
+if [[ "$EVENT" != "push" ]]; then
+  echo "Build number $DRONE_BUILD_PARENT failed because the event is not a push."
+  exit 1
+fi
+
+if [[ "$REFS" != "refs/heads/master" ]]; then
+  echo "Build number $DRONE_BUILD_PARENT failed because the reference is not refs/heads/master."
   exit 1
 fi
 

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -107,10 +107,8 @@ spec:
                 secretKeyRef:
                   name: keycloak-user
                   key: password
-            {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: ALLOW_SKIP
               value: "true"
-            {{ end }}
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -14,7 +14,7 @@ metadata:
   name: {{ .APP_NAME }}
   {{ end }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .STG_ENV) (eq .KUBE_NAMESPACE .PROD_ENV) }}
+  {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
   replicas: 2
   {{ else }}
   replicas: 1
@@ -107,6 +107,9 @@ spec:
                 secretKeyRef:
                   name: keycloak-user
                   key: password
+            {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+            - name: ALLOW_SKIP
+              value: "true"
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
@@ -115,8 +118,6 @@ spec:
             - name: FILE_VAULT_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk/file
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -107,8 +107,6 @@ spec:
                 secretKeyRef:
                   name: keycloak-user
                   key: password
-            - name: ALLOW_SKIP
-              value: "true"
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -110,6 +110,7 @@ spec:
             {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: ALLOW_SKIP
               value: "true"
+            {{ end }}
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -19,8 +19,6 @@ spec:
         - {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
         - {{.APP_NAME}}.uat.sas-notprod.homeoffice.gov.uk
-      {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-        - {{.APP_NAME}}.stg.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
         - {{ .PRODUCTION_URL }}
       {{ end }}
@@ -34,8 +32,6 @@ spec:
     - host: {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: {{.APP_NAME}}.uat.sas-notprod.homeoffice.gov.uk
-    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-    - host: preprod.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
     {{ else }}
     - host: {{ .PRODUCTION_URL }}
     {{ end }}

--- a/kube/app/ingress-internal.yml
+++ b/kube/app/ingress-internal.yml
@@ -17,8 +17,6 @@ spec:
         - {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
         - {{ .APP_NAME }}.internal.uat.sas-notprod.homeoffice.gov.uk
-      {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-        - {{ .APP_NAME }}.internal.stg.sas-notprod.homeoffice.gov.uk
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
       secretName: branch-tls-internal
@@ -28,10 +26,9 @@ spec:
   rules:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
     - host: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk
-    {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+    {{ end }}
+    {{ if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: {{ .APP_NAME }}.internal.uat.sas-notprod.homeoffice.gov.uk
-    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-    - host: {{ .APP_NAME }}.internal.stg.sas-notprod.homeoffice.gov.uk
     {{ end }}
       http:
         paths:

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -138,7 +138,7 @@ spec:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 name: {{ .APP_NAME }}-configmap-{{ .DRONE_SOURCE_BRANCH }}
                 {{ else }}
-                name: configmap
+                name: {{ .APP_NAME }}-configmap
                 {{ end }}
           env:
             - name: PROXY_CLIENT_SECRET

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -59,8 +59,6 @@ spec:
             - name: FILE_VAULT_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -140,7 +138,7 @@ spec:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 name: {{ .APP_NAME }}-configmap-{{ .DRONE_SOURCE_BRANCH }}
                 {{ else }}
-                name: {{ .APP_NAME }}-configmap
+                name: configmap
                 {{ end }}
           env:
             - name: PROXY_CLIENT_SECRET
@@ -160,8 +158,6 @@ spec:
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -140,7 +140,7 @@ spec:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 name: {{ .APP_NAME }}-configmap-{{ .DRONE_SOURCE_BRANCH }}
                 {{ else }}
-                name: configmap
+                name: {{ .APP_NAME }}-configmap
                 {{ end }}
           env:
             - name: PROXY_CLIENT_SECRET

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -16,8 +16,6 @@ spec:
     - fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
-    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-    - fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
     - fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
     {{ end }}
@@ -31,8 +29,6 @@ spec:
   - host: fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
   - host: fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
-  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-  - host: fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
   - host: fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
   {{ end }}


### PR DESCRIPTION
## What? 
add pipeline steps missing, remove staging and allow_skip
## Why? 
When promoting the uat env to production, it is found failing due to not being able to export the config repo.
## How? 
1. Add the following pipeline steps:
-sanity_check_build_prod and helpers
- clone_repos_prod
2. Removing staging from the code. 
3. Add a password condition for keycloak to skip only for uat and branch but required for production.
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


