### PR TITLE
TLF-201-coa-upload-answers-bug

### DIFF
--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -58,14 +58,18 @@ const getPersonalisation = (recipientType, req) => {
     has_leg_details: req.sessionModel.get('steps').includes('/legal-details') ? 'yes' : 'no',
     OISC_SRA_number: req.sessionModel.get('oisc-sra-number') ?? '',
     company_name: req.sessionModel.get('legal-company-name') ?? '',
-    leg_rep_address: req.sessionModel.get('steps').includes('/upload-letter') ? req.sessionModel.get('legalAddressDetails') : '',
+    leg_rep_address: req.sessionModel.get('steps').includes('/upload-letter') ?
+      req.sessionModel.get('legalAddressDetails') : '',
     details_updating: getLabel('which-details-updating', req.sessionModel.get('which-details-updating')),
     has_old_postcode: req.sessionModel.get('old-postcode') ? 'yes' : 'no',
     old_postcode: req.sessionModel.get('old-postcode') ?? '',
-    has_new_home_address: req.sessionModel.get('steps').includes('/home-address') ? 'yes' : 'no',
-    new_home_address: req.sessionModel.get('steps').includes('/upload-address') ? req.sessionModel.get('addressDetails') : '',
+    has_new_home_address: req.sessionModel.get('steps').includes('/home-address') ?
+      'yes' : 'no',
+    new_home_address: req.sessionModel.get('steps').includes('/upload-address') ?
+      req.sessionModel.get('addressDetails') : '',
     has_new_postal_address: req.sessionModel.get('steps').includes('/postal-address') ? 'yes' : 'no',
-    new_postal_address: req.sessionModel.get('steps').includes('/upload-postal-address') ? req.sessionModel.get('postalAddressDetails') : '',
+    new_postal_address: req.sessionModel.get('steps').includes('/upload-postal-address') ?
+      req.sessionModel.get('postalAddressDetails') : '',
     has_dependents: req.sessionModel.get('steps').includes('/dependant-summary') ? 'yes' : 'no',
     dependents: getDependants(req.sessionModel.get('dependants'))
   };

--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -72,9 +72,12 @@ const getPersonalisation = (recipientType, req) => {
 
   if (recipientType === 'business') {
     const identityDocuments = parseDocumentList(req.sessionModel.get('identity-documents'));
-    const homeAddressDocuments = parseDocumentList(req.sessionModel.get('home-address-documents'));
-    const postalAddressDocuments = parseDocumentList(req.sessionModel.get('postal-address-documents'));
-    const letterOfAuthority = parseDocumentList(req.sessionModel.get('letter-of-authority'));
+    const homeAddressDocuments = req.sessionModel.get('steps').includes('/upload-address') ?
+      parseDocumentList(req.sessionModel.get('home-address-documents')) : '';
+    const postalAddressDocuments = req.sessionModel.get('steps').includes('/upload-postal-address') ?
+      parseDocumentList(req.sessionModel.get('postal-address-documents')) : '';
+    const letterOfAuthority = req.sessionModel.get('steps').includes('/upload-letter') ?
+      parseDocumentList(req.sessionModel.get('letter-of-authority')) : '';
 
     return {
       ...basePersonalisation,

--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -58,14 +58,14 @@ const getPersonalisation = (recipientType, req) => {
     has_leg_details: req.sessionModel.get('steps').includes('/legal-details') ? 'yes' : 'no',
     OISC_SRA_number: req.sessionModel.get('oisc-sra-number') ?? '',
     company_name: req.sessionModel.get('legal-company-name') ?? '',
-    leg_rep_address: req.sessionModel.get('legalAddressDetails') ?? '',
+    leg_rep_address: req.sessionModel.get('steps').includes('/upload-letter') ? req.sessionModel.get('legalAddressDetails') : '',
     details_updating: getLabel('which-details-updating', req.sessionModel.get('which-details-updating')),
     has_old_postcode: req.sessionModel.get('old-postcode') ? 'yes' : 'no',
     old_postcode: req.sessionModel.get('old-postcode') ?? '',
     has_new_home_address: req.sessionModel.get('steps').includes('/home-address') ? 'yes' : 'no',
-    new_home_address: req.sessionModel.get('addressDetails') ?? '',
+    new_home_address: req.sessionModel.get('steps').includes('/upload-address') ? req.sessionModel.get('addressDetails') : '',
     has_new_postal_address: req.sessionModel.get('steps').includes('/postal-address') ? 'yes' : 'no',
-    new_postal_address: req.sessionModel.get('postalAddressDetails') ?? '',
+    new_postal_address: req.sessionModel.get('steps').includes('/upload-postal-address') ? req.sessionModel.get('postalAddressDetails') : '',
     has_dependents: req.sessionModel.get('steps').includes('/dependant-summary') ? 'yes' : 'no',
     dependents: getDependants(req.sessionModel.get('dependants'))
   };

--- a/apps/coa/sections/summary-data-sections.js
+++ b/apps/coa/sections/summary-data-sections.js
@@ -150,7 +150,10 @@ module.exports = {
       {
         step: '/upload-address',
         field: 'home-address-documents',
-        parse: documents => {
+        parse: (documents, req) => {
+          if (!req.sessionModel.get('steps').includes('/upload-address')) {
+            return null;
+          }
           return Array.isArray(documents) && documents.length > 0  ? documents.map(doc => doc.name).join('\n') : null;
         }
       },
@@ -178,7 +181,10 @@ module.exports = {
       {
         step: '/upload-postal-address',
         field: 'postal-address-documents',
-        parse: documents => {
+        parse: (documents, req) => {
+          if (!req.sessionModel.get('steps').includes('/upload-postal-address')) {
+            return null;
+          }
           return Array.isArray(documents) && documents.length > 0  ? documents.map(doc => doc.name).join('\n') : null;
         }
       },

--- a/apps/coa/views/request-submitted.html
+++ b/apps/coa/views/request-submitted.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$pageTitle}}
-    {{#t}}pages.privacy-declaration.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+    {{#t}}pages.request-submitted.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
   {{/pageTitle}}
   {{$page-content}}
     <div class="govuk-panel alert-complete govuk-panel--confirmation">


### PR DESCRIPTION
Relates [TLF-201](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-201)

## What? 

* Fixes bug where if the applicant completes a journey and uploads proof of address and then changes their answer for /which-details on check answers page to postal address, both uploads proofs will show as uploaded on check-answers page

* Fixes bug where pageTitle was incorrectly showing /request-submitted page

## Why? 
## How? 

Modified summary data sections to only show uploaded file if that step is in the current session

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


