### PR TITLE
Error handling on email notification

### DIFF
--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -124,7 +124,7 @@ module.exports = class SendEmailConfirmation {
       const errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
       const errorCode = err.code ? `${err.code} -` : '';
       const errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
-      
+
       req.log(
         'error',
         `Failed to send User Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')};`,

--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -124,9 +124,9 @@ module.exports = class SendEmailConfirmation {
       req.log(
         'error',
         `Failed to send User Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')}`,
-        err
+        JSON.stringify(err.response.data)
       );
-      throw err;
+      throw new Error(JSON.stringify(err.response.data));
     }
   }
 
@@ -150,9 +150,9 @@ module.exports = class SendEmailConfirmation {
       req.log(
         'error',
         `Failed to send Business Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')}`,
-        err
+        JSON.stringify(err.response.data)
       );
-      throw err;
+      throw new Error(JSON.stringify(err.response.data));
     }
   }
 

--- a/apps/coa/behaviours/send-email-notification.js
+++ b/apps/coa/behaviours/send-email-notification.js
@@ -121,12 +121,16 @@ module.exports = class SendEmailConfirmation {
         `User Confirmation Email sent successfully, reference number: ${req.sessionModel.get('uniqueRefNumber')}`
       );
     } catch (err) {
+      const errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
+      const errorCode = err.code ? `${err.code} -` : '';
+      const errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
+      
       req.log(
         'error',
-        `Failed to send User Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')}`,
-        JSON.stringify(err.response.data)
+        `Failed to send User Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')};`,
+        errorMessage
       );
-      throw new Error(JSON.stringify(err.response.data));
+      throw  Error(errorMessage);
     }
   }
 
@@ -147,12 +151,16 @@ module.exports = class SendEmailConfirmation {
         `Business Confirmation Email sent successfully, reference number: ${req.sessionModel.get('uniqueRefNumber')}`
       );
     } catch (err) {
+      const errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
+      const errorCode = err.code ? `${err.code} -` : '';
+      const errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
+
       req.log(
         'error',
-        `Failed to send Business Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')}`,
-        JSON.stringify(err.response.data)
+        `Failed to send Business Confirmation Email, reference number: ${req.sessionModel.get('uniqueRefNumber')};`,
+        errorMessage
       );
-      throw new Error(JSON.stringify(err.response.data));
+      throw Error(errorMessage);
     }
   }
 
@@ -161,9 +169,9 @@ module.exports = class SendEmailConfirmation {
       await this.sendUserEmailNotification(req);
       await this.sendCaseworkerEmailNotification(req);
 
-      req.log('info', 'Request to send email notifications completed successfully.');
+      req.log('info', 'Request to send notification emails completed successfully.');
     } catch(err) {
-      req.log('error', `Failed to send email notifications. ${JSON.stringify(err)}`);
+      req.log('error', `Failed to send all notifications emails. ${err}`);
       throw err;
     }
   }

--- a/apps/coa/behaviours/submit-notify.js
+++ b/apps/coa/behaviours/submit-notify.js
@@ -16,8 +16,8 @@ module.exports = superclass => class extends superclass {
     try {
       await notifyEmail.send(req, res, super.locals(req, res));
     } catch (error) {
-      req.log('error', 'Failed to send notification email:', error);
-      return next(Error(`Failed to send notification email: ${error}`));
+      req.log('error', 'Failed to send notification emails:', error);
+      return next(Error(`Failed to send notification emails: ${error}`));
     }
 
     return super.successHandler(req, res, next);


### PR DESCRIPTION
## What? 
Currently, it's not clear what errors occur in email notification requests, which makes debugging difficult. 
## Why? 
Currently it's not clear what errors occur on email notification requests, which makes it difficult to debug.
## How? 
Logs now include response data to list any errors associated with the failed request.
## Testing?

Tested locally and checked the logs to ensure that the list of errors was captured.

An example:

`Failed to send notification email: Error: {"errors":[{"error":"BadRequestError","message":"Can’t send to this recipient using a team-only API key"}],"status_code":400}`

`Failed to send notification email: Error: {"errors":[{"error":"ValidationError","message":"template_id is not a valid UUID"}],"status_code":400}`

`Failed to send notification email: Error: {"errors":[{"error":"AuthError","message":"Invalid token: service id is not the right data type"}],"status_code":403}`

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


