### PR TITLE
TLF-200 - Spinner functionality during upload

### DIFF
--- a/apps/coa/views/upload-address.html
+++ b/apps/coa/views/upload-address.html
@@ -8,6 +8,10 @@
       Upload a file
     </label>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="home-address-documents">
+    <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">Uploading your document...</span>
+    </div>
   </div>
 
   {{^values.home-address-documents}}

--- a/apps/coa/views/upload-identity.html
+++ b/apps/coa/views/upload-identity.html
@@ -1,13 +1,17 @@
 {{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}} {{$page-content}}
-<p>{{#t}}pages.upload-identity.upload-identity-intro{{/t}} {{#t}}pages.upload-identity.upload-identity-instructions{{/t}}</p>
-<p>{{#t}}pages.upload-identity.upload-identity-requirements{{/t}}</p>
-
+  <p>{{#t}}pages.upload-identity.upload-identity-intro{{/t}}
+  {{#t}}pages.upload-identity.upload-identity-instructions{{/t}}</p>
+  <p>{{#t}}pages.upload-identity.upload-identity-requirements{{/t}}</p>
 
   <div class="govuk-form-group">
     <label class="govuk-label bold" for="file-upload">
       Upload a file
     </label>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="identity-documents">
+    <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">Uploading your document...</span>
+    </div>
   </div>
 
   {{^values.identity-documents}}
@@ -31,10 +35,10 @@
   {{#markdown}}what-file-types{{/markdown}}
 
   {{#markdown}}what-counts-as-proof-of-identity{{/markdown}}
-  
-    <button class="govuk-button govuk-button" name="continueWithoutUpload" value="identity-documents">
-      {{#t}}buttons.continue{{/t}}
-    </button>
-    
+
+  <button class="govuk-button govuk-button uploadPageContinue" name="continueWithoutUpload" value="identity-documents">
+    {{#t}}buttons.continue{{/t}}
+  </button>
+
   {{/page-content}}
   {{/partials-page}}

--- a/apps/coa/views/upload-identity.html
+++ b/apps/coa/views/upload-identity.html
@@ -36,7 +36,7 @@
 
   {{#markdown}}what-counts-as-proof-of-identity{{/markdown}}
 
-  <button class="govuk-button govuk-button uploadPageContinue" name="continueWithoutUpload" value="identity-documents">
+  <button class="govuk-button govuk-button" name="continueWithoutUpload" value="identity-documents">
     {{#t}}buttons.continue{{/t}}
   </button>
 

--- a/apps/coa/views/upload-letter.html
+++ b/apps/coa/views/upload-letter.html
@@ -8,6 +8,10 @@
       Upload a file
     </label>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="letter-of-authority">
+    <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">Uploading your document...</span>
+    </div>
   </div>
 
   {{^values.letter-of-authority}}

--- a/apps/coa/views/upload-postal-address.html
+++ b/apps/coa/views/upload-postal-address.html
@@ -8,6 +8,10 @@
       Upload a file
     </label>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="postal-address-documents">
+    <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">Uploading your document...</span>
+    </div>
   </div>
 
   {{^values.postal-address-documents}}

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const loaderContainer = document.querySelector('#loader-container');
   const reportSubmitButton = document.querySelector('#report-submit');
   const fileUpload = document.getElementById('file-upload');
+  const uploadPageLoaderContainer = document.getElementById('upload-page-loading-spinner');
+  const continueWithoutUpload = document.getElementsByName('continueWithoutUpload');
 
   if (loaderContainer) {
     document.querySelector('#report-submit .govuk-button').addEventListener('click', () => {
@@ -24,9 +26,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if(fileUpload) {
+  if (fileUpload) {
     fileUpload.addEventListener('change', () => {
       document.querySelector('[name=file-upload-form]').submit();
+      uploadPageLoaderContainer.style.display = 'flex';
+      fileUpload.disabled = true;
+      fileUpload.ariaDisabled = true;
+      continueWithoutUpload.forEach(a => {
+        a.disabled = true;
+        a.ariaDisabled = true;
+      });
     });
   }
 });

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -423,5 +423,21 @@ pre.looped-records {
   height: 30px;
   animation: spin 1s linear infinite;
 }
+.spinner-container {
+  display: none;
+  margin-top: 20px;
+  align-items: center; /* Vertically center the spinner and message */
+}
+.spinner-message {
+ margin-left: 10px;
+}
+ @-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+ }
+ @keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+ }
 
 


### PR DESCRIPTION
### What
TLF-200- COA - File upload - Spinner functionality - [TLF-200](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-200)

### Why
- When a user selects a file to upload, the file upload process should trigger a visual loading spinner indicating the upload is in progress.
- The “Choose File” button should be disabled and the spinner will be displayed. 
- The “Continue” button should be disabled to prevent proceeding to the next page.
- Additionally, a message should be displayed to inform the user that the file upload is in progress.

### How
- the hidden `<div> upload-page-loading-spinner `and will show the container only during the file upload. Then the spinner loads and the makes the upload and continue button disabled.
  - assets/js/index.js
  - assets/scss/app.scss

### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local

