### PR TITLE
TLF-202:  FE validation on file upload

### DIFF
--- a/apps/coa/behaviours/save-document.js
+++ b/apps/coa/behaviours/save-document.js
@@ -37,7 +37,7 @@ module.exports = (documentCategory, fieldName) => superclass => class extends su
       if (invalidSize) {
         return validationErrorFunc('maxFileSize');
       } else if (invalidMimetype) {
-        return validationErrorFunc('fileType', ['JPG, JPEG, PNG or PDF']);
+        return validationErrorFunc('fileType');
       } else if (numberOfDocsUploaded >= documentCategoryConfig.limit) {
         return validationErrorFunc(documentCategoryConfig.limitValidationError, [documentCategoryConfig.limit]);
       } else if (isDuplicateFile) {

--- a/apps/coa/models/file-upload.js
+++ b/apps/coa/models/file-upload.js
@@ -8,6 +8,12 @@ const uuid = require('uuid').v4;
 const config = require('../../../config');
 const logger = require('hof/lib/logger')({ env: config.env });
 
+function sanitizeReqConf(reqConf) {
+  const sanitized = { ...reqConf };
+  sanitized.formData.document.value = '**REDACTED**';
+  return sanitized;
+}
+
 module.exports = class UploadModel extends Model {
   constructor(...args) {
     super(...args);
@@ -40,7 +46,7 @@ module.exports = class UploadModel extends Model {
         if (err) {
           logger.error(`File upload failed: ${err.message},
             error: ${JSON.stringify(err)},
-            reqConf: ${JSON.stringify(reqConf)}`);
+            reqConf: ${JSON.stringify(sanitizeReqConf(reqConf))}`);
           return reject(new Error(`File upload failed: ${err.message}`));
         }
 

--- a/apps/coa/translations/src/en/fields.json
+++ b/apps/coa/translations/src/en/fields.json
@@ -133,10 +133,12 @@
     "hint": "For example, 1208297A"
   },
   "brp-details" : {
-    "label": "What is your Biometric residence permit (BRP) number?"
+    "label": "What is your Biometric residence permit (BRP) number?",
+    "hint": "For example, ZU1234567"
   },
   "arc-details" : {
-    "label": "What is your Application registration card number?"
+    "label": "What is your Application registration card number?",
+    "hint": "For example, ZU1234567"
   },
   "old-address": {
     "legend": "Is {{#values.isApplicant}}your{{/values.isApplicant}}{{^values.isApplicant}}{{values.nameWithPossession}}{{/values.isApplicant}} old home address in the UK?",

--- a/apps/coa/translations/src/en/journey.json
+++ b/apps/coa/translations/src/en/journey.json
@@ -1,5 +1,6 @@
 {
   "header": "UKVI - Update address or legal representative",
   "serviceName": "Update address or legal representative",
-  "phase": "beta"
+  "phase": "beta",
+  "error": "Error"
 }

--- a/apps/coa/translations/src/en/validation.json
+++ b/apps/coa/translations/src/en/validation.json
@@ -185,7 +185,7 @@
         "required": "Select a file to upload",
         "unsaved": "Your file could not be uploaded – try again",
         "maxFileSize": "Your file must be smaller than 25MB",
-        "fileType": "Your file must be a {{fileType}}",
+        "fileType": "Your file must be a JPG, JPEG, PNG or PDF",
         "virusCheck": "The file you have uploaded may have a virus. Try a different file",
         "maxIdDocsUploads" : "You can only upload upto {{maxIdDocsUploads}} files or less. Remove a file before uploading another",
         "maxAddressDocsUploads" : "You can only upload upto {{maxAddressDocsUploads}} files or less. Remove a file before uploading another",

--- a/apps/coa/views/identity-number.html
+++ b/apps/coa/views/identity-number.html
@@ -1,6 +1,0 @@
-{{<partials-page}}
-  {{$page-content}}
-    {{#renderField}}identity-type{{/renderField}}
-    {{#input-submit}}continue{{/input-submit}}
-  {{/page-content}}
-{{/partials-page}}

--- a/apps/coa/views/upload-address.html
+++ b/apps/coa/views/upload-address.html
@@ -3,10 +3,16 @@
   {{#t}}pages.upload-address.upload-home-address-instructions{{/t}}</p>
   <p>{{#t}}pages.upload-address.upload-home-address-requirements{{/t}}</p>
 
-  <div class="govuk-form-group">
+  <div class="govuk-form-group" id="hofFileUpload">
     <label class="govuk-label bold" for="file-upload">
       Upload a file
     </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="home-address-documents">
     <div id="upload-page-loading-spinner" class="spinner-container">
       <div class="spinner-loader"></div>

--- a/apps/coa/views/upload-identity.html
+++ b/apps/coa/views/upload-identity.html
@@ -3,10 +3,16 @@
   {{#t}}pages.upload-identity.upload-identity-instructions{{/t}}</p>
   <p>{{#t}}pages.upload-identity.upload-identity-requirements{{/t}}</p>
 
-  <div class="govuk-form-group">
+  <div class="govuk-form-group" id="hofFileUpload">
     <label class="govuk-label bold" for="file-upload">
       Upload a file
     </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="identity-documents">
     <div id="upload-page-loading-spinner" class="spinner-container">
       <div class="spinner-loader"></div>

--- a/apps/coa/views/upload-identity.html
+++ b/apps/coa/views/upload-identity.html
@@ -26,16 +26,21 @@
 
   {{#values.identity-documents.length}}
   <h2 class="govuk-heading-m">You have uploaded {{values.identity-documents.length}} file(s)</h2>
-  <table class="loop-summary-table">
-    <tbody class="govuk-table__body">
-      {{#values.identity-documents}}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{name}}</td>
-        <td><a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.delete{{/t}}</a></td>
-      </tr>
-      {{/values.identity-documents}}
-    </tbody>
-  </table>
+
+  <div id="uploaded-documents" class="govuk-width-container">
+    {{#values.identity-documents}}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          {{name}}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+          <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.delete{{/t}}</a>
+        </div>
+    </div>
+    <div class="file-upload-hrline"></div>
+  {{/values.identity-documents}}
+  </div>
+
   {{/values.identity-documents.length}}
 
   {{#markdown}}what-file-types{{/markdown}}

--- a/apps/coa/views/upload-letter.html
+++ b/apps/coa/views/upload-letter.html
@@ -1,12 +1,17 @@
 {{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}} {{$page-content}}
-<p>{{#t}}pages.upload-letter.upload-letter-intro{{/t}} {{#t}}pages.upload-letter.upload-letter-instructions{{/t}}</p>
-<p>{{#t}}pages.upload-letter.upload-letter-requirements{{/t}}</p>
+  <p>{{#t}}pages.upload-letter.upload-letter-intro{{/t}} {{#t}}pages.upload-letter.upload-letter-instructions{{/t}}</p>
+  <p>{{#t}}pages.upload-letter.upload-letter-requirements{{/t}}</p>
 
-
-  <div class="govuk-form-group">
+  <div class="govuk-form-group" id="hofFileUpload">
     <label class="govuk-label bold" for="file-upload">
       Upload a file
     </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="letter-of-authority">
     <div id="upload-page-loading-spinner" class="spinner-container">
       <div class="spinner-loader"></div>

--- a/apps/coa/views/upload-postal-address.html
+++ b/apps/coa/views/upload-postal-address.html
@@ -3,10 +3,16 @@
   {{#t}}pages.upload-postal-address.upload-postal-instructions{{/t}}</p>
   <p>{{#t}}pages.upload-postal-address.upload-postal-requirements{{/t}}</p>
 
-  <div class="govuk-form-group">
+  <div class="govuk-form-group" id="hofFileUpload">
     <label class="govuk-label bold" for="file-upload">
       Upload a file
     </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="postal-address-documents">
     <div id="upload-page-loading-spinner" class="spinner-container">
       <div class="spinner-loader"></div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const fileUpload = document.getElementById('file-upload');
   const uploadPageLoaderContainer = document.getElementById('upload-page-loading-spinner');
   const continueWithoutUpload = document.getElementsByName('continueWithoutUpload');
+  const removeLinks = document.querySelectorAll('#uploaded-documents > div > div > a');
 
   if (loaderContainer) {
     document.querySelector('#report-submit .govuk-button').addEventListener('click', () => {
@@ -52,6 +53,9 @@ document.addEventListener('DOMContentLoaded', () => {
         continueWithoutUpload.forEach(a => {
           a.disabled = true;
           a.ariaDisabled = true;
+        });
+        removeLinks.forEach(a => {
+          a.classList.add('disabled-link');
         });
         break;
       default:

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const fileUploadErrorMsg = fileUploadComponent.querySelector('.govuk-error-message');
     switch (status) {
       case 'ready':
-        if (fileUploadComponent){
+        if (fileUploadComponent) {
           fileUploadComponent.classList.remove('govuk-form-group--error');
         }
         if (fileUploadErrorMsg) {
@@ -40,8 +40,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         break;
       case 'error':
-        if (fileUploadComponent){
-          fileUploadComponent.classList.add('govuk-form-group--error');  
+        if (fileUploadComponent) {
+          fileUploadComponent.classList.add('govuk-form-group--error');
           document.getElementById(`file-upload-error-${errorType}`).classList.remove('govuk-!-display-none');
         }
         break;
@@ -54,13 +54,15 @@ document.addEventListener('DOMContentLoaded', () => {
           a.ariaDisabled = true;
         });
         break;
+      default:
+        break;
     }
-  }
+  };
 
   if (fileUpload) {
     fileUpload.addEventListener('change', () => {
       fileUploadStatusHandler('ready');
-      let fileInfo = fileUpload.files && fileUpload.files.length > 0 ? fileUpload.files[0] : null;
+      const fileInfo = fileUpload.files && fileUpload.files.length > 0 ? fileUpload.files[0] : null;
       if (fileInfo) {
         if (fileInfo.size > config.upload.maxFileSizeInBytes) {
           fileUploadStatusHandler('error', 'maxFileSize');

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -440,4 +440,16 @@ pre.looped-records {
   100% { transform: rotate(360deg); }
  }
 
+.disabled-link {
+  pointer-events: none;
+}
 
+.file-upload-hrline {
+  display: block;
+  background: #bfc1c3;
+  border: 0;
+  height: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 0;
+}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -442,6 +442,7 @@ pre.looped-records {
 
 .disabled-link {
   pointer-events: none;
+  opacity: .5;
 }
 
 .file-upload-hrline {


### PR DESCRIPTION
## What? 
Add FE validation on file upload to prevent form submission if file size is bigger that the configured limit or file type is not allowed.
## Why? 
Currently, users receive a 413 error when trying to upload files larger than the configured limit. Or a validation error if the file type is not allowed. However, if the files are relatively large, there will be a noticeable latency to get the response from the server side.  
This also allows for immediate validation checks without unnecessarily querying the server side.
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
This PR also cover minor change to add hint for BRP and ARC fields, and removed redundant template [identity-number][TLF-209](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-209)
This PR also covers the changes for disabling remove link for the uploaded files [TLF-200](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-200)
And changes for the uploaded files layout changed from table to grid [TLF-230](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-230)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


