### PR TITLE
TLF-42: Revert Back the changes to use fv External ingress

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -157,9 +157,7 @@ spec:
               value: "http://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-              # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-              value: https://fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+              value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -212,7 +210,7 @@ spec:
         - name: certs
           secret:
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-            secretName: branch-tls-internal
+            secretName: branch-tls-external
             {{ else }}
             secretName: file-vault-cert
             {{ end }}

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -3,25 +3,12 @@ kind: Ingress
 metadata:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
   name: file-vault-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
-  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-  name: file-vault-ingress
-  {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
   {{ else }}
   name: file-vault-ingress
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  {{ file .FILEVAULT_INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
   {{ end }}
-
+{{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-  ingressClassName: nginx-internal
-  {{ else }}
   ingressClassName: nginx-external
-  {{ end }}
   tls:
   - hosts:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -30,28 +17,22 @@ spec:
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-    # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-    # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-    - fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+    - fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
     {{ end }}
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
     secretName: branch-tls-external
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     secretName: file-vault-cert
-    # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-    # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-    {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-    secretName: branch-tls-internal
     {{ end }}
   rules:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
   - host: fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
+  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+  - host: fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  - host: fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+  - host: fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
   {{ end }}
     http:
       paths:

--- a/kube/file-vault/file-vault-network-policy.yml
+++ b/kube/file-vault/file-vault-network-policy.yml
@@ -11,13 +11,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-          # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-          {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-          name: ingress-internal
-          {{ else }}
           name: ingress-external
-          {{ end }}
     ports:
     - port: 10080
       protocol: TCP


### PR DESCRIPTION
* Due to PECC FV internal ingress is used for timebeing
* Now fv url in prod is pointed to external ingress
* Reverting back the files and configs to use the external ingress