### PR TITLE
TLF-42-Master: Use Node 18 temporarily for testing prod setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,6 @@ environment:
   APP_NAME: coa
   PROD_ENV: sas-coa-prod
   BRANCH_ENV: sas-coa-branch
-  STG_ENV: sas-coa-stg
   UAT_ENV: sas-coa-uat
   PRODUCTION_URL: www.update-my-details.homeoffice.gov.uk
   IMAGE_URL: quay.io/ukhomeofficedigital
@@ -22,7 +21,6 @@ trigger:
     - feature/*
     - master
   
-
 linting: &linting
   pull: if-not-exists
   image: node:18
@@ -38,6 +36,12 @@ unit_tests: &unit_tests
     NOTIFY_KEY: USE_MOCK
   commands:
     - yarn run test:unit
+
+sonar_scanner: &sonar_scanner
+  pull: if-not-exists
+  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
+  commands:
+    - sonar-scanner -Dproject.settings=./sonar-project.properties
 
 acceptance_tests: &acceptance_tests
   pull: if-not-exists
@@ -58,12 +62,29 @@ steps:
         include:
         - master
         - feature/*
-      
+      event: [push, pull_request]
+
+  # Trivy Security Scannner for scanning OS related vulnerabilities in Base image of Dockerfile
+  - name: scan_image_os
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
+      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+      SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: false
+      ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
+    when:
       event: [push, pull_request]
 
   - name: setup_deploy
     pull: if-not-exists
-    image: node:18.12.1
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -92,6 +113,14 @@ steps:
         include:
           - master
           - feature/*
+      event: push
+
+  - name: sonar_scanner_deploy
+    <<: *sonar_scanner
+    when:
+      branch:
+        include:
+          - master
       event: push
 
   - name: build_image
@@ -129,8 +158,8 @@ steps:
           - feature/*
       event: [push, pull_request]
 
-  # Trivy Security Scannner
-  - name: scan-image
+  # Trivy Security Scannner for scanning nodejs packages in Yarn
+  - name: scan_node_packages
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     resources:
@@ -139,15 +168,12 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
-      SEVERITY: MEDIUM,HIGH,CRITICAL
+      SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree --format table
       FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: hof-services-config/Change_Of_Address/trivy-cve-exceptions.txt
+      IGNORE_UNFIXED: false
+      ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      event:
-      - pull_request
-      - push
-      - tag
+      event: [push, pull_request]
 
   # Deploy to pull request UAT environment
   - name: deploy_to_branch
@@ -166,7 +192,6 @@ steps:
         include:
           - master
           - feature/*
-
       event: pull_request
 
   - name: setup_branch
@@ -181,8 +206,7 @@ steps:
       branch:
         include:
           - master
-          - feature/*
-          
+          - feature/*   
       event: pull_request
 
   - name: linting_branch
@@ -192,7 +216,6 @@ steps:
         include:
           - master
           - feature/*
-         
       event: [push, pull_request]
 
   - name: unit_tests_branch
@@ -202,8 +225,16 @@ steps:
         include:
           - master
           - feature/*
-         
       event: [push, pull_request]
+
+  - name: sonar_scanner_branch
+    <<: *sonar_scanner
+    when:
+      branch:
+        include:
+          - master
+          - feature/*
+      event: pull_request
 
   - name: acceptance_tests_branch
     <<: *acceptance_tests
@@ -297,7 +328,7 @@ steps:
       target: PROD
       event: promote
 
-    # Deploy to Production environment
+  # Deploy to Production environment
   - name: deploy_to_prod
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
@@ -336,8 +367,8 @@ steps:
     when:
       cron: tear_down_pr_envs
       event: cron
-
-    # CRON job steps that runs security scans using Snyk & Trivy
+  
+  # CRON job steps that runs security scans using Trivy
   - name: cron_clone_repos
     image: alpine/git
     environment:
@@ -354,7 +385,7 @@ steps:
   - name: cron_build_image
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
     commands:
-      - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
+      - docker build --no-cache  --build-arg BASE_IMAGE=${BASE_IMAGE} -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
     volumes:
       - name: dockersock
         path: /var/run
@@ -362,33 +393,32 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_snyk_scan
-    pull: if-not-exists
-    image: node:18
-    environment:
-      SNYK_TOKEN:
-        from_secret: snyk_token
-    commands:
-      - yarn install --frozen-lockfile
-      - yarn run postinstall
-      - yarn run test:snyk
-    when:
-      cron: security_scans
-      event: cron
-
-  - name: cron_trivy_scan
+  - name: cron_trivy_scan_node_packages
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
         IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
-        SEVERITY: MEDIUM,HIGH,CRITICAL
+        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SEVERITY: UNKOWN,LOW,MEDIUM,HIGH,CRITICAL
         FAIL_ON_DETECTION: false
-        IGNORE_UNFIXED: true
-        ALLOW_CVE_LIST_FILE: hof-services-config/Change_Of_Address/trivy-cve-exceptions.txt
+        IGNORE_UNFIXED: false
+        ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
       cron: security_scans
       event: cron
- 
+
+  - name: cron_trivy_scan_image_os
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    pull: always
+    environment:
+        IMAGE_NAME: node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        FAIL_ON_DETECTION: false
+        IGNORE_UNFIXED: false
+        ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
+    when:
+      cron: security_scans
+      event: cron
 
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
@@ -399,7 +429,7 @@ steps:
       failure: ignore
       icon_url: http://readme.drone.io/0.5/logo_dark.svg
       icon.url: http://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of GRO has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
+      template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
       username: Drone
       webhook:
         from_secret: slack_webhook

--- a/.drone.yml
+++ b/.drone.yml
@@ -437,6 +437,24 @@ steps:
       cron: tear_down_pr_envs
       event: cron
       status: failure
+  
+  - name: cron_notify_slack_security_scans
+    pull: if-not-exists
+    image: plugins/slack
+    settings:
+      channel: sas-hof-security
+      failure: ignore
+      icon_url: http://readme.drone.io/0.5/logo_dark.svg
+      icon.url: http://readme.drone.io/0.5/logo_dark.svg
+      template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
+      username: Drone
+      webhook:
+        from_secret: slack_webhook
+    when:
+      cron: security_scans
+      event: cron
+      status: failure
+
 
 services:
   - name: docker

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -42,5 +42,5 @@ sleep $READY_FOR_TEST_DELAY
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   echo "App Branch - coa-$DRONE_SOURCE_BRANCH.internal.sas-coa-branch.homeoffice.gov.uk"
-  echo "Data Service Branch - data-service-$DRONE_SOURCE_BRANCH.sas-coa-branch.homeoffice.gov.uk"
+  echo "File Vault Branch - fv-$DRONE_SOURCE_BRANCH.sas-coa-branch.homeoffice.gov.uk"
 fi

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -157,9 +157,7 @@ spec:
               value: "http://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-              # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-              value: https://fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+              value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -212,7 +210,7 @@ spec:
         - name: certs
           secret:
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-            secretName: branch-tls-internal
+            secretName: branch-tls-external
             {{ else }}
             secretName: file-vault-cert
             {{ end }}

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -3,25 +3,12 @@ kind: Ingress
 metadata:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
   name: file-vault-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
-  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-  name: file-vault-ingress
-  {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
   {{ else }}
   name: file-vault-ingress
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  {{ file .FILEVAULT_INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
   {{ end }}
-
+  {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-  ingressClassName: nginx-internal
-  {{ else }}
   ingressClassName: nginx-external
-  {{ end }}
   tls:
   - hosts:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -30,28 +17,20 @@ spec:
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-    # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-    # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-    - fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+    - fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
     {{ end }}
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
     secretName: branch-tls-external
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     secretName: file-vault-cert
-    # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-    # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-    {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-    secretName: branch-tls-internal
     {{ end }}
   rules:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
+  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
   - host: fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-  # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-  # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-  - host: fv-{{ .APP_NAME }}.sas.internal.homeoffice.gov.uk
+  - host: fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
   {{ end }}
     http:
       paths:

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - fv-{{ .DRONE_BUILD_NUMBER }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     - fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
@@ -26,7 +25,7 @@ spec:
     {{ end }}
   rules:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+  - host: fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
   - host: fv-{{ .APP_NAME }}.uat.sas-notprod.homeoffice.gov.uk
   {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}

--- a/kube/file-vault/file-vault-network-policy.yml
+++ b/kube/file-vault/file-vault-network-policy.yml
@@ -11,13 +11,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          # This is temporary change using ingress internal for prod. We will revert back the change after PECC expires
-          # https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19781
-          {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-          name: ingress-internal
-          {{ else }}
           name: ingress-external
-          {{ end }}
     ports:
     - port: 10080
       protocol: TCP

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=Change-Of-Address
+sonar.projectName=Change-Of-Address
+sonar.language=js
+sonar.sources=apps
+sonar.tests=test
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+


### PR DESCRIPTION
## What? 

* With the time constraints we are planning to test the prod setup
* This Testing is done to find any missing configurations, secrets, certs, ingress policies, keycloak
* Test the logging and monitoring added in Sydig &  Opensearch
* Helpful in advancing with OAT documentation.
## Why? 
* TLF-42-2 branch is used for fixing the vulnerabilities and testing the compatibility of Node 20
* We need some testing to be done on Branch env
## How? 
* Replaces internal ingress of Filevault with external ingress Filevault
* Add Trivy steps to scan OS and Package vulnerabilities
* Add missing Trivy Steps

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


