### PR TITLE
TLF-42-pipeline: Add the new slack channels and secrets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -427,10 +427,11 @@ steps:
     settings:
       channel: sas-hof-build-notify
       failure: ignore
-      icon_url: http://readme.drone.io/0.5/logo_dark.svg
-      icon.url: http://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
-      username: Drone
+      icon.url: https://readme.drone.io/logo.svg
+      template: >
+            :x: CRON Job `tear_down_pr_envs` for *Change of Address (COA)* has failed.
+            Repo `{{ repo.name }}` branch <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> for commit <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+      username: Drone_CI
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
@@ -444,10 +445,11 @@ steps:
     settings:
       channel: sas-hof-security
       failure: ignore
-      icon_url: http://readme.drone.io/0.5/logo_dark.svg
-      icon.url: http://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
-      username: Drone
+      icon.url: https://readme.drone.io/logo.svg
+      template: >
+            :x: CRON Job `security_scans` for *Change of Address (COA)* has failed.
+            Repo `{{ repo.name }}` branch <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> for commit <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+      username: Drone_CI
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -400,7 +400,7 @@ steps:
         IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKOWN,LOW,MEDIUM,HIGH,CRITICAL
-        FAIL_ON_DETECTION: false
+        FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
@@ -413,7 +413,7 @@ steps:
     environment:
         IMAGE_NAME: node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-        FAIL_ON_DETECTION: false
+        FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -425,14 +425,14 @@ steps:
     pull: if-not-exists
     image: plugins/slack
     settings:
-      channel: sas-build
+      channel: sas-hof-build-notify
       failure: ignore
       icon_url: http://readme.drone.io/0.5/logo_dark.svg
       icon.url: http://readme.drone.io/0.5/logo_dark.svg
       template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
       username: Drone
       webhook:
-        from_secret: slack_webhook
+        from_secret: slack_sas_hof_build_notify_webhook
     when:
       cron: tear_down_pr_envs
       event: cron
@@ -449,7 +449,7 @@ steps:
       template: "CRON Job {{build.deployTo}} of Change of Address has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
       username: Drone
       webhook:
-        from_secret: slack_webhook
+        from_secret: slack_sas_hof_security_webhook
     when:
       cron: security_scans
       event: cron


### PR DESCRIPTION
## What? 
All the HOF services have the slack notifications but they are misconfigured. sas-build channel is archived. We have decided to use exisiting slack channel to notify us  build status of security scanners and tear down envs
Cron jobs are useful for monitoring the execution and status of the cron jobs and help in quickly identifying issues, ensuring that the jobs are running as expected

## Why? 
These notifications are important and alert us for any vulnerabilities detected in cron security scanners
We will also be notified about cron steps build success and failures tearing down envs created by pull requests save  on infrastructure costs

## How? 
I have added the webhooks as secrets to the Drone secrets. Updated the Slack channels for the two types of cron jobs.

## Testing?
We will monitor them after merging to Master. I have tested by sending curl request to post to a channel for both the slack channels.

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


