### PR TITLE
TLF-266 - Missing page titles

### DIFF
--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -35,8 +35,8 @@ module.exports = {
       next: '/what-you-need',
       pagination: {
         nextPage: {
-          label: "what-you-need",
-          link: "/what-you-need"
+          label: 'what-you-need',
+          link: '/what-you-need'
         }
       }
     },
@@ -45,12 +45,12 @@ module.exports = {
       backLink: false,
       pagination: {
         previousPage: {
-          label: "overview",
-          link: "/overview"
+          label: 'overview',
+          link: '/overview'
         },
         nextPage: {
-          label: "proof-of-identity",
-          link: "/proof-of-identity"
+          label: 'proof-of-identity',
+          link: '/proof-of-identity'
         }
       }
     },
@@ -59,12 +59,12 @@ module.exports = {
       backLink: false,
       pagination: {
         previousPage: {
-          label: "what-you-need",
-          link: "/what-you-need"
+          label: 'what-you-need',
+          link: '/what-you-need'
         },
         nextPage: {
-          label: "proof-of-address",
-          link: "/proof-of-address"
+          label: 'proof-of-address',
+          link: '/proof-of-address'
         }
       }
     },
@@ -73,12 +73,12 @@ module.exports = {
       backLink: false,
       pagination: {
         previousPage: {
-          label: "proof-of-identity",
-          link: "/proof-of-identity"
+          label: 'proof-of-identity',
+          link: '/proof-of-identity'
         },
         nextPage: {
-          label: "update-your-details",
-          link: "/update-details"
+          label: 'update-your-details',
+          link: '/update-details'
         }
       }
     },
@@ -87,8 +87,8 @@ module.exports = {
       backLink: false,
       pagination: {
         previousPage: {
-          label: "proof-of-address",
-          link: "/proof-of-address"
+          label: 'proof-of-address',
+          link: '/proof-of-address'
         }
       }
     },

--- a/apps/coa/index.js
+++ b/apps/coa/index.js
@@ -32,23 +32,65 @@ module.exports = {
   steps: {
     '/overview': {
       behaviours: [sessionDefaults],
-      next: '/what-you-need'
+      next: '/what-you-need',
+      pagination: {
+        nextPage: {
+          label: "what-you-need",
+          link: "/what-you-need"
+        }
+      }
     },
     '/what-you-need': {
       next: '/proof-of-identity',
-      backLink: false
+      backLink: false,
+      pagination: {
+        previousPage: {
+          label: "overview",
+          link: "/overview"
+        },
+        nextPage: {
+          label: "proof-of-identity",
+          link: "/proof-of-identity"
+        }
+      }
     },
     '/proof-of-identity': {
       next: '/proof-of-address',
-      backLink: false
+      backLink: false,
+      pagination: {
+        previousPage: {
+          label: "what-you-need",
+          link: "/what-you-need"
+        },
+        nextPage: {
+          label: "proof-of-address",
+          link: "/proof-of-address"
+        }
+      }
     },
     '/proof-of-address': {
       next: '/update-details',
-      backLink: false
+      backLink: false,
+      pagination: {
+        previousPage: {
+          label: "proof-of-identity",
+          link: "/proof-of-identity"
+        },
+        nextPage: {
+          label: "update-your-details",
+          link: "/update-details"
+        }
+      }
     },
     '/update-details': {
       next: '/applicant-details',
-      backLink: false
+      backLink: false,
+      pagination: {
+        previousPage: {
+          label: "proof-of-address",
+          link: "/proof-of-address"
+        }
+      }
     },
     '/applicant-details': {
       fields: ['applicant-full-name', 'applicant-dob', 'applicant-nationality', 'applicant-unique-number'],

--- a/apps/coa/translations/src/en/pages.json
+++ b/apps/coa/translations/src/en/pages.json
@@ -1,4 +1,19 @@
 {
+  "overview": {
+    "header": "Update your details without an account"
+  },
+  "what-you-need": {
+    "header": "{{#t}}pages.overview.header{{/t}}"
+  },
+  "proof-of-identity": {
+    "header": "{{#t}}pages.overview.header{{/t}}"
+  },
+  "proof-of-address": {
+    "header": "{{#t}}pages.overview.header{{/t}}"
+  },
+  "update-details": {
+    "header": "{{#t}}pages.overview.header{{/t}}"
+  },
   "applicant-details": {
     "header": "Applicant details",
     "application-details-intro": "Enter the details of the person whose details you want to update. Their details must match the identity document that UK Visas and Immigration holds on record."

--- a/apps/coa/translations/src/en/pages.json
+++ b/apps/coa/translations/src/en/pages.json
@@ -1,18 +1,18 @@
 {
   "overview": {
-    "header": "Update your details without an account"
+    "header": "Overview"
   },
   "what-you-need": {
-    "header": "{{#t}}pages.overview.header{{/t}}"
+    "header": "What you need"
   },
   "proof-of-identity": {
-    "header": "{{#t}}pages.overview.header{{/t}}"
+    "header": "Proof of identity"
   },
   "proof-of-address": {
-    "header": "{{#t}}pages.overview.header{{/t}}"
+    "header": "Proof of address"
   },
   "update-details": {
-    "header": "{{#t}}pages.overview.header{{/t}}"
+    "header": "Update your details"
   },
   "applicant-details": {
     "header": "Applicant details",

--- a/apps/coa/views/overview.html
+++ b/apps/coa/views/overview.html
@@ -1,26 +1,11 @@
 {{<partials-page}}
-{{$page-content}}
+  {{$page-content}}
 
-{{> partials-overview-header}}
+    {{> partials-content-links}}
 
-{{> partials-content-links}}
+    {{#markdown}}overview-intro{{/markdown}}
 
-{{#markdown}}overview-intro{{/markdown}}
+    {{> partials-pagination}}
 
-<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="Pagination">
-  <div class="govuk-pagination__next">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/what-you-need" rel="next">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.next{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.what-you-need{{/t}}</span>
-    </a>
-  </div>
-</nav>
-
-{{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/apps/coa/views/partials/overview-header.html
+++ b/apps/coa/views/partials/overview-header.html
@@ -1,1 +1,0 @@
-<h1 class="govuk-heading-l">Update your details without an account</h1>

--- a/apps/coa/views/partials/pagination.html
+++ b/apps/coa/views/partials/pagination.html
@@ -1,0 +1,31 @@
+<nav class="govuk-pagination govuk-pagination--block" role="pagination" aria-label="Pagination">
+
+    {{#options.pagination.previousPage}}
+    <div class="govuk-pagination__prev">
+        <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="{{options.pagination.previousPage.link}}" rel="prev">
+        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+        </svg>
+        <span class="govuk-pagination__link-title">
+            {{#t}}buttons.previous{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
+        </span>
+        <span class="govuk-visually-hidden">:</span>
+        <span class="govuk-pagination__link-label">{{#t}}buttons.{{options.pagination.previousPage.label}}{{/t}}</span>
+        </a>
+    </div>
+    {{/options.pagination.previousPage}}
+    {{#options.pagination.nextPage}}
+    <div class="govuk-pagination__next">
+        <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="{{options.pagination.nextPage.link}}" rel="next">
+        <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+        </svg>
+        <span class="govuk-pagination__link-title">
+            {{#t}}buttons.next{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
+        </span>
+        <span class="govuk-visually-hidden">:</span>
+        <span class="govuk-pagination__link-label">{{#t}}buttons.{{options.pagination.nextPage.label}}{{/t}}</span>
+        </a>
+    </div>
+    {{/options.pagination.nextPage}}
+</nav>

--- a/apps/coa/views/proof-of-address.html
+++ b/apps/coa/views/proof-of-address.html
@@ -1,40 +1,11 @@
 {{<partials-page}}
-{{$page-content}}
+  {{$page-content}}
 
-{{> partials-overview-header}}
+    {{> partials-content-links}}
 
-{{> partials-content-links}}
+    {{#markdown}}address-intro{{/markdown}}
 
-{{#markdown}}address-intro{{/markdown}}
+    {{> partials-pagination}}
 
-
-<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="Pagination">
-  <div class="govuk-pagination__prev">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/proof-of-identity" rel="prev">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.previous{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.proof-of-identity{{/t}}</span>
-    </a>
-  </div>
-  <div class="govuk-pagination__next">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/update-details" rel="next">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.next{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.update-your-details{{/t}}</span>
-    </a>
-  </div>
-</nav>
-
-
-{{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/apps/coa/views/proof-of-identity.html
+++ b/apps/coa/views/proof-of-identity.html
@@ -1,41 +1,11 @@
 {{<partials-page}}
-{{$page-content}}
+  {{$page-content}}
 
-{{> partials-overview-header}}
+    {{> partials-content-links}}
 
-{{> partials-content-links}}
+    {{#markdown}}identity-intro{{/markdown}}
 
-{{#markdown}}identity-intro{{/markdown}}
+    {{> partials-pagination}}
 
-
-
-<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="Pagination">
-  <div class="govuk-pagination__prev">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/what-you-need" rel="prev">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.previous{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.what-you-need{{/t}}</span>
-    </a>
-  </div>
-  <div class="govuk-pagination__next">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/proof-of-address" rel="next">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.next{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.proof-of-address{{/t}}</span>
-    </a>
-  </div>
-</nav>
-
-
-{{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/apps/coa/views/update-details.html
+++ b/apps/coa/views/update-details.html
@@ -1,27 +1,11 @@
 {{<partials-page}}
-{{$page-content}}
+  {{$page-content}}
 
-{{> partials-overview-header}}
+  {{> partials-content-links}}
 
-{{> partials-content-links}}
+  {{#markdown}}update-details-intro{{/markdown}}
 
-{{#markdown}}update-details-intro{{/markdown}}
+  {{> partials-pagination}}
 
-<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="Pagination">
-  <div class="govuk-pagination__prev">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/proof-of-address" rel="prev">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.previous{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.proof-of-address{{/t}}</span>
-    </a>
-  </div>
-</nav>
-
-
-{{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/apps/coa/views/what-you-need.html
+++ b/apps/coa/views/what-you-need.html
@@ -1,39 +1,11 @@
 {{<partials-page}}
-{{$page-content}}
+  {{$page-content}}
 
-{{> partials-overview-header}}
+    {{> partials-content-links}}
 
-{{> partials-content-links}}
+    {{#markdown}}what-you-need-intro{{/markdown}}
 
-{{#markdown}}what-you-need-intro{{/markdown}}
+    {{> partials-pagination}}
 
-<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="Pagination">
-  <div class="govuk-pagination__prev">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/overview" rel="prev">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.previous{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.overview{{/t}}</span>
-    </a>
-  </div>
-  <div class="govuk-pagination__next">
-    <a class="govuk-link--no-visited-state govuk-link--no-underline govuk-pagination__link" href="/proof-of-identity" rel="next">
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">
-        {{#t}}buttons.next{{/t}}<span class="govuk-visually-hidden"> {{#t}}buttons.page{{/t}}</span>
-      </span>
-      <span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label">{{#t}}buttons.proof-of-identity{{/t}}</span>
-    </a>
-  </div>
-</nav>
-
-
-{{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Change of Address",
+  "appName": "UKVI - Update address or legal representative",
   "theme": "govUK",
   "behaviours": [
     "hof/components/clear-session",

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ app.use((req, res, next) => {
 
   bb.on('file', (key, file, fileInfo) => {
     logger.info(`Processing file: 
-      filename: ${fileInfo.filename},
+      filename: ${sanitiseFilename(fileInfo.filename)},
       encoding: ${fileInfo.encoding},
       mimeType: ${fileInfo.mimeType}`
     );

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
 // Use regex to replace the middle part of the filename with **REDACTED**,
 // keeping the first 2 and last 2 characters before the extension
-const sanitiseFilename = filename => filename.replace(/^(.{2}).*(.{2}\.[^.]+)$/, '$1**REDACTED**$2');
+const sanitiseFilename = filename => filename?.replace(/^(.{2}).*(.{2}\.[^.]+)$/, '$1**REDACTED**$2');
 
 module.exports = { sanitiseFilename };


### PR DESCRIPTION
## What? 

Bugfix for missing page titles
[TLF-266](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-266) - Missing page name in starter page titles

## Why? 
The first 5 'update your details without an account' pages: overview, what you need, proof of identity, proof of address and update your details, start with a hyphen. They should have the page name in front of the hyphen.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
- Refactored code: extracted pagination to the separate template
- Applied sanitiseFile method before logging
- Cookies bar heading has been update with correct service name
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


