### PR TITLE
TLF-286: removed external ports from keycloak-proxy container;

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -169,9 +169,6 @@ spec:
             - "--resources=uri=/*"
             - "--enable-logging=true"
             - "--enable-json-logging=true"
-          ports:
-            - containerPort: 10080
-            - containerPort: 10443
           securityContext:
             runAsNonRoot: true
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
## What? 
Removed external ports from keycloak-proxy container
## Why? 
Bug has been logged on PROD and UAT env
 [TLF-286](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-286) - Getting 500 Internal server error message when upload a file of size 24.9mb

The issue appear to be with request timeout on Keycloak proxy (which is the part of File-vault service). Which is a broader issue and is covered separately.
  
During the investigation unrelated misconfiguration has been noticed of deployment for file-vault service, where two containers keycloak-proxy and nginx-proxy had the same ports.

## How? 
Removed ports from keycloak-proxy, so the nginx-proxy will be the only entry point.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


