### PR TITLE
Feature/cron notification update

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -378,7 +378,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: test_cron_adi
+      cron: test_cron-adi
       event: cron
 
   - name: cron_build_image
@@ -389,7 +389,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: test_cron_adi
+      cron: test_cron-adi
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -403,7 +403,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test_cron_adi
+      cron: test_cron-adi
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -416,7 +416,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test_cron_adi
+      cron: test_cron-adi
       event: cron
 
   # Slack notification upon a CRON job fail
@@ -428,7 +428,7 @@ steps:
       failure: ignore
       template: >
           :x: Build for cron tear down pr envs failed.
-          Cron job failed to execute and failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
+          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Build Link:* <{{build.link}}|View Build Details>
       webhook:
@@ -455,7 +455,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: test_cron_adi
+      cron: test_cron-adi
       event: cron
       status: [ failure ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -436,7 +436,7 @@ steps:
     when:
       cron: tear_down_pr_envs
       event: cron
-      status: failure
+      status: [ failure ]
   
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -457,7 +457,7 @@ steps:
     when:
       cron: test_cron_adi
       event: cron
-      status: failure
+      status: [ failure ]
 
 services:
   - name: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -450,7 +450,7 @@ steps:
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
       template: |-
-        *✘ Failed:* `{{ build.event }}` / Step: '{{ failed.steps }}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        *✘ Failed:* `{{ build.event }}` / Step: $DRONE_FAILED_STEPS / $${DRONE_FAILED_STEPS} / <{{ build.link }}|Build: #{{ build.number }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -361,9 +361,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      #  - bin/clean_up.sh $${BRANCH_ENV}
-      # test alert with syntax error 
-      - bin/clean_up.s $${BRANCH_ENV}
+      - bin/clean_up.sh $${BRANCH_ENV}
 
     when:
       cron: tear_down_pr_envs

--- a/.drone.yml
+++ b/.drone.yml
@@ -363,10 +363,9 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - bin/clean_up.s $${BRANCH_ENV}
+      - bin/clean_up.sh $${BRANCH_ENV}
     when:
-      cron: test-cron-adi
-#     cron: tear_down_pr_envs
+      cron: tear_down_pr_envs
       event: cron
   
   # CRON job steps that runs security scans using Trivy
@@ -444,8 +443,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: test-cron-adi
-#     cron: tear_down_pr_envs
+      cron: tear_down_pr_envs
       event: cron
       event: cron
       status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -451,7 +451,7 @@ steps:
       icon.url: https://readme.drone.io/logo.svg
       template: >
         {{#success build.status}}
-          :white_check_mark: Build {{build.link}} for cron security scans succeeded. :tada:
+          :white_check_mark: Build for cron security scans succeeded. :tada:
           Trivy didn't detect any vulnerabilities. Hence the pipeline steps ran succesfull
           *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
@@ -459,8 +459,8 @@ steps:
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
         {{else}}
-          :x: Build {{build.link}} for cron security scans failed. :two-siren:
-          Trivy has detected vulnerabilities and resulted in failed step, Please fix them
+          :x: Build for cron security scans failed. :two-siren:
+          Trivy has detected vulnerabilities and hence resulted in failed step, Please use following information to fix them
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>

--- a/.drone.yml
+++ b/.drone.yml
@@ -450,7 +450,7 @@ steps:
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
       template: |-
-        *✘ Failed:* `{{ build.event }}` / Step: '${DRONE_STEP_NAME}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        *✘ Failed:* `{{ build.event }}` / Step: '{{ step.name }}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -399,7 +399,7 @@ steps:
     environment:
         IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
-        SEVERITY: UNKOWN,LOW,MEDIUM,HIGH,CRITICAL
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
@@ -450,7 +450,7 @@ steps:
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
       template: |-
-        *✘ Failed:* `{{ build.event }}` at step '${DRONE_STEP_NAME}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        *✘ Failed:* `{{ build.event }}` / Step: '${DRONE_STEP_NAME}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -452,15 +452,14 @@ steps:
       template: >
         {{#success build.status}}
           :white_check_mark: Build for cron security scans succeeded. :tada:
-          Trivy didn't detect any vulnerabilities. Hence the pipeline steps ran succesfull
+          Great news! Trivy scan has completed and no vulnerabilities were detected in the target.
           *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
         {{else}}
-          :x: Build for cron security scans failed. :two-siren:
-          Trivy has detected vulnerabilities and hence resulted in failed step, Please use following information to fix them
+          :x: Trivy has detected a vulnerability. As a result, the build has failed. Please prioritize reviewing and addressing this issue. :two-siren: 
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>

--- a/.drone.yml
+++ b/.drone.yml
@@ -429,10 +429,10 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-          *✘ {{ uppercasefirst build.status }}*: Cron job `tear_down_pr_envs` failed to tears down the deployments in BRANCH enviroment.
+          *✘ {{ uppercasefirst build.status }}*: Cron job `tear_down_pr_envs` failed to tear down the deployments in the BRANCH environment.
 
           *Repo* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> | *Branch* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | *Commit* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-            
+
           *Build <{{build.link}}|#{{build.number}}>*
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook

--- a/.drone.yml
+++ b/.drone.yml
@@ -428,26 +428,16 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-        {{#success build.status}}
-          :white_check_mark: Build for cron tear down pr envs succeeded. :tada:
-          Cron job has torn down all the deployments created by Pull requests in Branch env
-          *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
-          *Build Link:* <{{build.link}}|View Build Details>
-        {{else}}
           :x: Build for cron tear down pr envs failed. :two-siren: 
           Cron job failed to execute and failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Build Link:* <{{build.link}}|View Build Details>
-        {{/success}}
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
       cron: tear_down_pr_envs
       event: cron
-      event: cron
       status:
-        - success
         - failure
   
   - name: cron_notify_slack_security_scans
@@ -457,15 +447,6 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-        {{#success build.status}}
-          :white_check_mark: Build for cron security scans succeeded. :tada:
-          Great news! Trivy scan has completed and no vulnerabilities were detected in the target.
-          *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
-          *Build Link:* <{{build.link}}|View Build Details>
-          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
-        {{else}}
           :x: Build for cron security scans failed. :two-siren: 
           Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. 
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
@@ -473,14 +454,12 @@ steps:
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
-        {{/success}}
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
       cron: security_scans
       event: cron
       status:
-        - success
         - failure
 
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -404,7 +404,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adis
+      cron: test-cron-adi
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -417,7 +417,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adis
+      cron: test-cron-adi
       event: cron
 
   # Slack notification upon a CRON job fail

--- a/.drone.yml
+++ b/.drone.yml
@@ -403,7 +403,6 @@ steps:
     when:
       cron: security_scans
       event: cron
-      status: [success, failure]
 
   - name: cron_trivy_scan_node_packages
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -417,6 +416,7 @@ steps:
     when:
       cron: security_scans
       event: cron
+      status: [success, failure]
 
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
@@ -426,13 +426,11 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-          :x: Build for cron tear down pr envs failed. 
+          *✘ {{ uppercasefirst build.status }}*: Cron job `tear_down_pr_envs` failed to tears down the deployments in BRANCH enviroment.
 
-          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline.
-
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}>
-          
-          *Build Link:* <{{build.link}}|View Build Details> 
+          *Repo* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> | *Branch* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | *Commit* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+            
+          *Build <{{build.link}}|#{{build.number}}>*
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
@@ -447,19 +445,11 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-          :x: Build for cron security scans failed. 
+          *✘ {{ uppercasefirst build.status }}*: Cron job `security_scans` failed. Trivy has detected vulnerabilities, causing the build to fail.
 
-          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue.
-
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
-
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
-
-          *Build Link:* <{{build.link}}|View Build Details>
-
-          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-
-          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
+          *Repo* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> | *Branch* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | *Commit* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+            
+          *Build <{{build.link}}|#{{build.number}}>*
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -420,7 +420,7 @@ steps:
       event: cron
 
   # Slack notification upon a CRON job fail
-  - name: cron_notify_slack_test-cron-adi
+  - name: cron_notify_slack_tear_down_pr_envs
     pull: if-not-exists
     image: plugins/slack:1.4.1
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -438,7 +438,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: test-cron-adi
+      cron: tear_down_pr_envs
       event: cron
       status: failure
   

--- a/.drone.yml
+++ b/.drone.yml
@@ -427,10 +427,10 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-          :x: Build for cron tear down pr envs failed.
-          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
-          *Build Link:* <{{build.link}}|View Build Details>
+          :x: Build for cron tear down pr envs failed. \n
+          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline. \n
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> \n
+          *Build Link:* <{{build.link}}|View Build Details> \n
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
@@ -445,13 +445,13 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-          :x: Build for cron security scans failed.
-          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. 
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
-          *Build Link:* <{{build.link}}|View Build Details>
-          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
+          :x: Build for cron security scans failed. \n
+          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. \n 
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> \n
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> \n
+          *Build Link:* <{{build.link}}|View Build Details> \n
+          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}> \n
+          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}> \n
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -450,7 +450,7 @@ steps:
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
       template: |-
-        *✘ Failed:* `{{ build.event }}` / Step: '{{ step.name }}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        *✘ Failed:* `{{ build.event }}` / Step: '{{ failed.steps }}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -427,10 +427,13 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-          :x: Build for cron tear down pr envs failed. \n
-          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline. \n
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> \n
-          *Build Link:* <{{build.link}}|View Build Details> \n
+          :x: Build for cron tear down pr envs failed. 
+
+          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline.
+
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}>
+          
+          *Build Link:* <{{build.link}}|View Build Details> 
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
@@ -445,13 +448,18 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-          :x: Build for cron security scans failed. \n
-          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. \n 
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> \n
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> \n
-          *Build Link:* <{{build.link}}|View Build Details> \n
-          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}> \n
-          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}> \n
+          :x: Build for cron security scans failed. 
+
+          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue.
+
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
+
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+
+          *Build Link:* <{{build.link}}|View Build Details>
+
+          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -461,7 +461,6 @@ steps:
       status:
         - failure
 
-
 services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind

--- a/.drone.yml
+++ b/.drone.yml
@@ -451,9 +451,9 @@ steps:
       icon.url: https://readme.drone.io/logo.svg
       template: >
         {{#success build.status}}
-          :white_check_mark: Build {{build.link}} succeeded. :tada:
-          *Repository:* {{repo.name}}
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}
+          :white_check_mark: Build {{build.link}} for cron security scans succeeded. :tada:
+          *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
@@ -464,8 +464,8 @@ steps:
             {{/success}}
           {{/each}}
         {{else}}
-          :x: Build {{build.link}} failed. :sob:
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}>
+          :x: Build {{build.link}} for cron security scans failed. :sob:
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>

--- a/.drone.yml
+++ b/.drone.yml
@@ -452,7 +452,7 @@ steps:
       template: >
         {{#success build.status}}
           :white_check_mark: Build {{build.link}} for cron security scans succeeded. :tada:
-          * Trivy didn't detect any vulnerabilities *
+          * Trivy didn't detect any vulnerabilities. Hence the pipeline steps ran succesfully *
           *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
@@ -465,7 +465,7 @@ steps:
             {{/success}}
           {{/each}}
         {{else}}
-          :x: Build {{build.link}} for cron security scans failed. :sob:
+          :x: Build {{build.link}} for cron security scans failed. :siren:
           * Trivy has detected vulnerabilities and resulted in failed step, Please fix them *
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>

--- a/.drone.yml
+++ b/.drone.yml
@@ -452,32 +452,20 @@ steps:
       template: >
         {{#success build.status}}
           :white_check_mark: Build {{build.link}} for cron security scans succeeded. :tada:
-          * Trivy didn't detect any vulnerabilities. Hence the pipeline steps ran succesfully *
+          Trivy didn't detect any vulnerabilities. Hence the pipeline steps ran succesfull
           *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
-          *Steps Passed:* 
-          {{#each build.steps}}
-            {{#success this.status}}
-              - {{this.name}}
-            {{/success}}
-          {{/each}}
         {{else}}
-          :x: Build {{build.link}} for cron security scans failed. :siren:
-          * Trivy has detected vulnerabilities and resulted in failed step, Please fix them *
+          :x: Build {{build.link}} for cron security scans failed. :two-siren:
+          Trivy has detected vulnerabilities and resulted in failed step, Please fix them
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
-          *Steps Failed:* 
-          {{#each build.steps}}
-            {{#failure this.status}}
-              - {{this.name}}
-            {{/failure}}
-          {{/each}}
         {{/success}}
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -451,11 +451,12 @@ steps:
       icon.url: https://readme.drone.io/logo.svg
       template: >
         {{#success build.status}}
-          :white_check_mark: Build #{{build.number}} succeeded. :tada:
+          :white_check_mark: Build {{build.link}} succeeded. :tada:
           *Repository:* {{repo.name}}
-          *Branch:* {{build.branch}}
-          *Commit:* {{commit.sha}} - {{commit.message}}
-          *Author:* {{commit.author}}
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}
+          *Build Link:* <{{build.link}}|View Build Details>
+          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
           *Steps Passed:* 
           {{#each build.steps}}
             {{#success this.status}}
@@ -463,11 +464,12 @@ steps:
             {{/success}}
           {{/each}}
         {{else}}
-          :x: Build #{{build.number}} failed. :sob:
-          *Repository:* {{repo.name}}
-          *Branch:* {{build.branch}}
-          *Commit:* {{commit.sha}} - {{commit.message}}
-          *Author:* {{commit.author}}
+          :x: Build {{build.link}} failed. :sob:
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}
+          *Build Link:* <{{build.link}}|View Build Details>
+          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
           *Steps Failed:* 
           {{#each build.steps}}
             {{#failure this.status}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -364,7 +364,7 @@ steps:
     commands:
       - bin/clean_up.sh $${BRANCH_ENV}
     when:
-      cron: tear_down_pr_envs
+      cron: test-cron-adi
       event: cron
   
   # CRON job steps that runs security scans using Trivy
@@ -378,7 +378,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_build_image
@@ -389,7 +389,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -403,7 +403,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -416,11 +416,11 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   # Slack notification upon a CRON job fail
-  - name: cron_notify_slack_tear_down_pr_envs
+  - name: cron_notify_slack_test-cron-adi
     pull: if-not-exists
     image: plugins/slack:1.4.1
     settings:
@@ -437,7 +437,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: tear_down_pr_envs
+      cron: test-cron-adi
       event: cron
       status: [ failure ]
   
@@ -459,12 +459,12 @@ steps:
           *Build Link:* <{{build.link}}|View Build Details>
 
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-          
+
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
       status: [ failure ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -366,7 +366,7 @@ steps:
     # test alert with syntax error 
       - bin/clean_up.s $${BRANCH_ENV}
     when:
-      cron: test-cron-adi
+      cron: tear_down_pr_envs
       event: cron
   
   # CRON job steps that runs security scans using Trivy
@@ -439,7 +439,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: test-cron-adi
+      cron: tear_down_pr_envs
       event: cron
       status: [ failure ]
   

--- a/.drone.yml
+++ b/.drone.yml
@@ -404,7 +404,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: test-cron-adis
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -417,7 +417,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: test-cron-adis
       event: cron
 
   # Slack notification upon a CRON job fail

--- a/.drone.yml
+++ b/.drone.yml
@@ -465,8 +465,8 @@ steps:
           {{/each}}
         {{else}}
           :x: Build {{build.link}} failed. :sob:
-          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}
-          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}>
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>

--- a/.drone.yml
+++ b/.drone.yml
@@ -449,7 +449,7 @@ steps:
           *✘ {{ uppercasefirst build.status }}*: Cron job `security_scans` has failed. Prioritise reviewing build logs and addressing issues.
 
           *Repo* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> | *Branch* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | *Commit* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-            
+
           *Build <{{build.link}}|#{{build.number}}>*
       webhook:
         from_secret: slack_sas_hof_security_webhook

--- a/.drone.yml
+++ b/.drone.yml
@@ -449,16 +449,41 @@ steps:
       channel: sas-hof-security
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
-      template: |-
-        *✘ Failed:* `{{ build.event }}` / Step: $DRONE_FAILED_STEPS / $${DRONE_FAILED_STEPS} / <{{ build.link }}|Build: #{{ build.number }}>
-        Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+      template: >
+        {{#success build.status}}
+          :white_check_mark: Build #{{build.number}} succeeded. :tada:
+          *Repository:* {{repo.name}}
+          *Branch:* {{build.branch}}
+          *Commit:* {{commit.sha}} - {{commit.message}}
+          *Author:* {{commit.author}}
+          *Steps Passed:* 
+          {{#each build.steps}}
+            {{#success this.status}}
+              - {{this.name}}
+            {{/success}}
+          {{/each}}
+        {{else}}
+          :x: Build #{{build.number}} failed. :sob:
+          *Repository:* {{repo.name}}
+          *Branch:* {{build.branch}}
+          *Commit:* {{commit.sha}} - {{commit.message}}
+          *Author:* {{commit.author}}
+          *Steps Failed:* 
+          {{#each build.steps}}
+            {{#failure this.status}}
+              - {{this.name}}
+            {{/failure}}
+          {{/each}}
+        {{/success}}
       username: Drone_CI
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
       cron: test-cron-adi
       event: cron
-      status: failure
+      status:
+        - success
+        - failure
 
 
 services:

--- a/.drone.yml
+++ b/.drone.yml
@@ -436,8 +436,7 @@ steps:
     when:
       cron: tear_down_pr_envs
       event: cron
-      status:
-        - failure
+      status: failure
   
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -458,8 +457,7 @@ steps:
     when:
       cron: test_cron_adi
       event: cron
-      status:
-        - failure
+      status: failure
 
 services:
   - name: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -295,7 +295,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - bin/deploy.sh tear_down
+      - bin/deploy.s tear_down
     when:
       branch: master
       event: push

--- a/.drone.yml
+++ b/.drone.yml
@@ -247,7 +247,6 @@ steps:
         include:
           - master
           - feature/*
-
       event: [push, pull_request]
 
   - name: deploy_to_uat
@@ -379,7 +378,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: security_scans
+      cron: test_cron_adi
       event: cron
 
   - name: cron_build_image
@@ -390,7 +389,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: security_scans
+      cron: test_cron_adi
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -404,7 +403,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: test_cron_adi
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -417,7 +416,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: test_cron_adi
       event: cron
 
   # Slack notification upon a CRON job fail
@@ -428,7 +427,7 @@ steps:
       channel: sas-hof-build-notify
       failure: ignore
       template: >
-          :x: Build for cron tear down pr envs failed. :two-siren: 
+          :x: Build for cron tear down pr envs failed.
           Cron job failed to execute and failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Build Link:* <{{build.link}}|View Build Details>
@@ -447,7 +446,7 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-          :x: Build for cron security scans failed. :two-siren: 
+          :x: Build for cron security scans failed.
           Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. 
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
@@ -457,7 +456,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: security_scans
+      cron: test_cron_adi
       event: cron
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -448,7 +448,6 @@ steps:
     settings:
       channel: sas-hof-security
       failure: ignore
-      icon.url: https://readme.drone.io/logo.svg
       template: >
         {{#success build.status}}
           :white_check_mark: Build for cron security scans succeeded. :tada:
@@ -459,14 +458,14 @@ steps:
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
         {{else}}
-          :x: Trivy has detected a vulnerability. As a result, the build has failed. Please prioritize reviewing and addressing this issue. :two-siren: 
+          :x: Build for cron security scans failed. :two-siren: 
+          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue. 
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
         {{/success}}
-      username: Drone_CI
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -353,7 +353,7 @@ steps:
       branch: master
       event: push
 
-  # CRON job step that tears down our pull request UAT environments
+  # CRON job step that tears down our pull request BRANCH environments
   - name: cron_tear_down
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
@@ -365,7 +365,8 @@ steps:
     commands:
       - bin/clean_up.sh $${BRANCH_ENV}
     when:
-      cron: tear_down_pr_envs
+      cron: test-cron-adi
+#     cron: tear_down_pr_envs
       event: cron
   
   # CRON job steps that runs security scans using Trivy
@@ -379,7 +380,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_build_image
@@ -390,7 +391,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -404,7 +405,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -417,7 +418,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
 
   # Slack notification upon a CRON job fail
@@ -427,20 +428,29 @@ steps:
     settings:
       channel: sas-hof-build-notify
       failure: ignore
-      icon.url: https://readme.drone.io/logo.svg
       template: >
-            *✘ {{ uppercasefirst build.status }}*: CRON Job `tear_down_pr_envs` for *Change of Address (COA)* has failed.
-
-            Branch <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | Commit <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-            
-            *Build <{{build.link}}|#{{build.number}}>*
-      username: Drone_CI
+        {{#success build.status}}
+          :white_check_mark: Build for cron tear down pr envs succeeded. :tada:
+          Cron job has torn down all the deployments created by Pull requests in Branch env
+          *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+          *Build Link:* <{{build.link}}|View Build Details>
+        {{else}}
+          :x: Build for cron tear down pr envs failed. :two-siren: 
+          Cron job failed to execute and failed to tear the deployments in Branch Env. Please use the information below to fix pipeline
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
+          *Build Link:* <{{build.link}}|View Build Details>
+        {{/success}}
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: tear_down_pr_envs
+      cron: test-cron-adi
+#     cron: tear_down_pr_envs
       event: cron
-      status: failure
+      event: cron
+      status:
+        - success
+        - failure
   
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -469,7 +479,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: test-cron-adi
+      cron: security_scans
       event: cron
       status:
         - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -362,7 +362,9 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - bin/clean_up.sh $${BRANCH_ENV}
+    #  - bin/clean_up.sh $${BRANCH_ENV}
+    # test alert with syntax error 
+      - bin/clean_up.s $${BRANCH_ENV}
     when:
       cron: test-cron-adi
       event: cron

--- a/.drone.yml
+++ b/.drone.yml
@@ -168,6 +168,7 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
+      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: false
@@ -362,9 +363,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-    #  - bin/clean_up.sh $${BRANCH_ENV}
-    # test alert with syntax error 
-      - bin/clean_up.s $${BRANCH_ENV}
+      - bin/clean_up.sh $${BRANCH_ENV}
     when:
       cron: tear_down_pr_envs
       event: cron
@@ -400,7 +399,7 @@ steps:
     environment:
         IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
-        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
@@ -413,7 +412,8 @@ steps:
     pull: always
     environment:
         IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
-        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml

--- a/.drone.yml
+++ b/.drone.yml
@@ -295,7 +295,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - bin/deploy.s tear_down
+      - bin/deploy.sh tear_down
     when:
       branch: master
       event: push
@@ -363,7 +363,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - bin/clean_up.sh $${BRANCH_ENV}
+      - bin/clean_up.s $${BRANCH_ENV}
     when:
       cron: test-cron-adi
 #     cron: tear_down_pr_envs

--- a/.drone.yml
+++ b/.drone.yml
@@ -450,7 +450,7 @@ steps:
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
       template: |-
-        *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        *✘ Failed:* `{{ build.event }}` at step '${DRONE_STEP_NAME}' / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:

--- a/.drone.yml
+++ b/.drone.yml
@@ -459,6 +459,7 @@ steps:
           *Build Link:* <{{build.link}}|View Build Details>
 
           *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+          
           *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
       webhook:
         from_secret: slack_sas_hof_security_webhook

--- a/.drone.yml
+++ b/.drone.yml
@@ -448,7 +448,7 @@ steps:
       channel: sas-hof-security
       failure: ignore
       template: >
-          *✘ {{ uppercasefirst build.status }}*: Cron job `security_scans` failed. Trivy has detected vulnerabilities, causing the build to fail.
+          *✘ {{ uppercasefirst build.status }}*: Cron job `security_scans` has failed. Prioritise reviewing build logs and addressing issues.
 
           *Repo* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> | *Branch* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | *Commit* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
             

--- a/.drone.yml
+++ b/.drone.yml
@@ -378,7 +378,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: test_cron-adi
+      cron: test-cron-adi
       event: cron
 
   - name: cron_build_image
@@ -389,7 +389,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: test_cron-adi
+      cron: test-cron-adi
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -403,7 +403,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test_cron-adi
+      cron: test-cron-adi
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -416,7 +416,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: test_cron-adi
+      cron: test-cron-adi
       event: cron
 
   # Slack notification upon a CRON job fail
@@ -455,7 +455,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: test_cron-adi
+      cron: test-cron-adi
       event: cron
       status: [ failure ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -74,7 +74,6 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
-      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: false
@@ -168,7 +167,6 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
-      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: false
@@ -393,12 +391,11 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_trivy_scan_node_packages
+  - name: cron_trivy_scan_image_os
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-        IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
-        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
@@ -406,13 +403,13 @@ steps:
     when:
       cron: security_scans
       event: cron
+      status: [success, failure]
 
-  - name: cron_trivy_scan_image_os
+  - name: cron_trivy_scan_node_packages
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-        IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
-        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        IMAGE_NAME: coa:${DRONE_COMMIT_SHA}
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -379,7 +379,7 @@ steps:
     commands:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
-      cron: security_scans
+      cron: test-cron-adi
       event: cron
 
   - name: cron_build_image
@@ -390,7 +390,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: security_scans
+      cron: test-cron-adi
       event: cron
 
   - name: cron_trivy_scan_node_packages
@@ -404,7 +404,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: test-cron-adi
       event: cron
 
   - name: cron_trivy_scan_image_os
@@ -417,13 +417,13 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: test-cron-adi
       event: cron
 
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
     pull: if-not-exists
-    image: plugins/slack
+    image: plugins/slack:1.4.1
     settings:
       channel: sas-hof-build-notify
       failure: ignore
@@ -438,28 +438,25 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: tear_down_pr_envs
+      cron: test-cron-adi
       event: cron
       status: failure
   
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
-    image: plugins/slack
+    image: plugins/slack:1.4.1
     settings:
       channel: sas-hof-security
       failure: ignore
       icon.url: https://readme.drone.io/logo.svg
-      template: >
-            *✘ {{ uppercasefirst build.status }}*: CRON Job `security_scans` for *Change of Address (COA)* has failed.
-
-            Branch <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{build.branch}}> | Commit <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-            
-            *Build <{{build.link}}|#{{build.number}}>*
+      template: |-
+        *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+        Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
       username: Drone_CI
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: security_scans
+      cron: test-cron-adi
       event: cron
       status: failure
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -361,7 +361,10 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - bin/clean_up.sh $${BRANCH_ENV}
+      #  - bin/clean_up.sh $${BRANCH_ENV}
+      # test alert with syntax error 
+      - bin/clean_up.s $${BRANCH_ENV}
+
     when:
       cron: tear_down_pr_envs
       event: cron

--- a/.drone.yml
+++ b/.drone.yml
@@ -452,6 +452,7 @@ steps:
       template: >
         {{#success build.status}}
           :white_check_mark: Build {{build.link}} for cron security scans succeeded. :tada:
+          * Trivy didn't detect any vulnerabilities *
           *Repository:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>
@@ -465,6 +466,7 @@ steps:
           {{/each}}
         {{else}}
           :x: Build {{build.link}} for cron security scans failed. :sob:
+          * Trivy has detected vulnerabilities and resulted in failed step, Please fix them *
           *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
           *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
           *Build Link:* <{{build.link}}|View Build Details>

--- a/1
+++ b/1
@@ -1,0 +1,9 @@
+Test Slack notifications
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch feature/cron-notification-update
+# Changes to be committed:
+#	modified:   .drone.yml
+#

--- a/1
+++ b/1
@@ -1,9 +1,0 @@
-Test Slack notifications
-
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-#
-# On branch feature/cron-notification-update
-# Changes to be committed:
-#	modified:   .drone.yml
-#

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Accept a build Argument named BASE_IMAGE
 FROM node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
 USER root
 


### PR DESCRIPTION
## What? 
Fixing the cron notification for hof services. 
We have updated the slack notifications and webhooks, Drone steps including the templates
Templates now check only for failures of build and post notifications of builds in the slack channels
https://collaboration.homeoffice.gov.uk/jira/browse/TLF-249

## Why? 
Team have decided to fix these Drone cron jobs
One of Cron job runs weekly once on fridays to tear down deployments triggered by pull requests
Another Cron job will post notifications when the trivy scan step has failed
 

## How? 
Webhooks have been created and added to Drone Pipeline
App has been created in Slack to use as bot user for posting notifications
Uses latest slack plugin image.


## Testing?
Alerts notifications are tested by forcing steps to fail.

<img width="581" alt="Screenshot 2024-08-07 at 14 15 16" src="https://github.com/user-attachments/assets/5909a1d8-d1c3-4906-90e9-6008357df4cf">
<img width="585" alt="Screenshot 2024-08-07 at 14 12 58" src="https://github.com/user-attachments/assets/0fad2200-f584-4c6f-b67a-5a7501826ee8">
<img width="1710" alt="Screenshot 2024-08-07 at 14 13 22" src="https://github.com/user-attachments/assets/1bbc482e-a31a-45b8-99e8-eb8e10eafbca">

Upon success we dont receive alert notifications
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/c3555f7f-01db-41be-905a-60b552a3d8d4">


## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


