### PR TITLE
TLF-307: Fix a bug with filevault cert

### DIFF
--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -20,7 +20,7 @@ spec:
     {{ end }}
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
     secretName: branch-tls-external
-    {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+    {{ else }}
     secretName: file-vault-cert
     {{ end }}
   rules:


### PR DESCRIPTION
## What? 

* Add a condition to use file-vault cert by ingress
* This bug could have picked while we switched from external to internal and then to external during PECC
* We have fixed it manually in production deployment.
* This is to ensure the changes stay permanent

## Why? 
* cert errors can break the application and backend
* Ensure certs are used by ingress as we expose the ingress to https

## How? 
* replace condition to use file-vault cert for UAT and Prod Env. In future for Staging Env

## Testing?
We have tested manually and cert error has been fixed. running same changes via pipeline
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


