### PR TITLE
HOFF-959: Toggle back to Master branch hof-services-config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,7 @@ steps:
       DRONE_GIT_TOKEN:
         from_secret: drone_git_token
     commands:
-      - git clone --branch HOFF-959 https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
+      - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
     when:
       branch:
         include:


### PR DESCRIPTION
## What? 

* Remove the flag that clones a feature branch which was added for branch testing

* Now clones the default master branch

* FIxes Drone Pipeline

## Why? 
* We have merged hof-services-config feature branch to Master branch
* This feature branch is deleted is unavailable hence we can remove this to pull the default master branch

## How? 

* Remove "--branch HOFF-959" from git clone command

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging


