### PR TITLE
adding PVC to service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -286,10 +286,11 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: push
+      event: pull_request
     depends_on:
       - clone_repos
       - image_to_quay
+      - deploy_to_branch
 
 
 # Checks a build being promoted has passed, is on master which effectively means a healthy build on UAT

--- a/.drone.yml
+++ b/.drone.yml
@@ -279,6 +279,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: "1Gi"
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
@@ -329,6 +331,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: "10Gi"
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -286,12 +286,10 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: pull_request
+      event: push
     depends_on:
       - clone_repos
       - image_to_quay
-      - deploy_to_branch
-
 
 # Checks a build being promoted has passed, is on master which effectively means a healthy build on UAT
   - name: sanity_check_build_prod

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,36 +10,80 @@ export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-exte
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+deploy_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd -f kube/redis/redis-persistent-volume-claim.yml
+  fi
+
+  $kd -f kube/redis/redis-service.yml \
+    -f kube/redis/redis-network-policy.yml \
+    -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd --delete -f kube/redis/redis-persistent-volume-claim.yml
+  fi
+
+  $kd --delete -f kube/redis/redis-service.yml \
+    -f kube/redis/redis-network-policy.yml \
+    -f kube/redis/redis-deployment.yml
+}
+
+set_redis_persistence_settings() {
+  export REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')
+  export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+  export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted}
+  export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+
+  if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+    export REDIS_PERSISTENCE_ENABLED=true
+    export REDIS_PERSISTENCE_SIZE=10Gi
+  elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+    export REDIS_PERSISTENCE_ENABLED=true
+    export REDIS_PERSISTENCE_SIZE=1Gi
+  else
+    export REDIS_PERSISTENCE_ENABLED=false
+  fi
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  set_redis_persistence_settings
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/file-vault -f kube/app -f kube/redis 
+  $kd --delete -f kube/file-vault -f kube/app
+  delete_redis
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
 fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+set_redis_persistence_settings
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
   $kd -f kube/file-vault/file-vault-ingress.yml 
-  $kd -f kube/redis -f kube/file-vault -f kube/app
+  deploy_redis
+  $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/redis -f kube/file-vault -f kube/app
+  deploy_redis
+  $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
-  $kd -f kube/redis -f kube/file-vault -f kube/app
+  deploy_redis
+  $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
-  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/redis
+  $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
+  deploy_redis
   $kd  -f kube/file-vault -f kube/app/deployment.yml
 fi
 

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -8,6 +8,8 @@ metadata:
   name: redis
   {{ end }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -29,14 +31,24 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: redis
           # redis:v7.0.15
           image: quay.io/ukhomeofficedigital/hof-docker-redis:7.0.15@sha256:cd4965fbb8aa6e4eba058985cc52f6a3ececdfa6d79ba44206f051f72a1f0611
+          args:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --dir
+            - /data
+            - --protected-mode
+            - "no"
           ports:
             - containerPort: 6379
           volumeMounts:
-            - mountPath: /var/lib/redis
+            - mountPath: /data
               name: data
           securityContext:
             runAsNonRoot: true
@@ -48,5 +60,19 @@ spec:
               cpu: "100m"
               memory: "200Mi"
       volumes:
+        {{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+        - name: data
+          persistentVolumeClaim:
+            {{ if eq .REDIS_PERSISTENCE_EXISTING_CLAIM "" }}
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-pvc
+            {{ end }}
+            {{ else }}
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+            {{ end }}
+        {{ else }}
         - name: data
           emptyDir: {}
+        {{ end }}

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -64,11 +64,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             {{ if eq .REDIS_PERSISTENCE_EXISTING_CLAIM "" }}
-            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-            claimName: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
-            {{ else }}
             claimName: redis-pvc
-            {{ end }}
             {{ else }}
             claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
             {{ end }}

--- a/kube/redis/redis-persistent-volume-claim.yml
+++ b/kube/redis/redis-persistent-volume-claim.yml
@@ -1,11 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: redis-pvc
-  {{ end }}
 spec:
   accessModes:
     - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}

--- a/kube/redis/redis-persistent-volume-claim.yml
+++ b/kube/redis/redis-persistent-volume-claim.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-pvc
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}


### PR DESCRIPTION
## What? 
This pull request adds support for persistent storage for Redis deployments in Kubernetes, replacing ephemeral storage with persistent volumes and claims. It introduces new configuration files for `PersistentVolume` and `PersistentVolumeClaim` resources, and updates the Redis deployment to use these resources. The configuration is dynamic, supporting different environments (production, branch, etc.) with conditional naming and storage sizes.

Persistent storage support for Redis:

* Added `redis-persistent-volume.yml` to define a `PersistentVolume` with conditional naming and storage size based on the environment.
* Added `redis-persistent-volume-claim.yml` to define a `PersistentVolumeClaim` with conditional naming, storage class, and volume binding, supporting different sizes for production and non-production environments.
* Updated `redis-deployment.yml` to use a `persistentVolumeClaim` for the Redis data volume instead of an `emptyDir`, with claim names set dynamically based on the environment.
## Why? 
PersistentVolume ensures that data (like Redis cache/session state) survives pod restarts, rescheduling, or crashes — without it, everything stored in the container is lost the moment it stops running.

## How? 
Config changes

## Testing?
Restart pods and observe behaviour

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
